### PR TITLE
Update platform-specific dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,19 @@
 [dependencies]
     # IMPORTANT: Enable the "derive" feature to access Clap's derive macros.
     clap = {version = "4.5.23", features = ["derive"]}
-    clipboard-win = "5.4.0"
     eframe = "0.30.0"
     rfd = "0.15.2"
-    windows = {version = "0.59.0", features = [
-        "Win32_Foundation",
-        "Win32_UI_WindowsAndMessaging"
-    ]}
     winit = "0.30.8"
 egui = "0.30"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[target.'cfg(windows)'.dependencies]
+    clipboard-win = "5.4.0"
+    windows = {version = "0.59.0", features = [
+        "Win32_Foundation",
+        "Win32_UI_WindowsAndMessaging"
+    ]}
+
+[target.'cfg(unix)'.dependencies]
+    arboard = "3"


### PR DESCRIPTION
## Summary
- move `clipboard-win` and `windows` crates to a Windows-specific section
- add Linux/Unix clipboard crate

## Testing
- `cargo check` *(fails: failed to download from `https://index.crates.io/config.json`)*

 