### PR TITLE
Make folder tag output path configurable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ serde_json = "1.0"
 
 [target.'cfg(not(windows))'.dependencies]
     arboard = "3"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/file_ops.rs
+++ b/src/file_ops.rs
@@ -1,7 +1,7 @@
 //! # File Operations Module
 //!
 //! This module is responsible for processing files in a directory by reading their contents,
-//! filtering by file extension, and writing them into a single tagged output file (`tags_output.txt`).
+//! filtering by file extension, and writing them into a caller-selected tagged output file.
 //!
 //! # Features
 //! - Recursively or non-recursively scan directories.
@@ -17,7 +17,7 @@
 //! - [`is_human_readable`]: Checks if a file has an allowed extension.
 //!
 //! # Output Behavior
-//! - Always creates (or overwrites) `tags_output.txt` in the current working directory.
+//! - Creates (or overwrites) the output file requested by the caller.
 //! - Each file is written in the format:
 //!   ```xml
 //!   <relative\path\to\file.rs>
@@ -30,14 +30,25 @@
 //! - UTF-8 file reading is assumed; non-UTF8 files are skipped with a warning.
 
 use std::fs::{read_dir, File};
-use std::io::{Read, Write};
+use std::io::{ErrorKind, Write};
 use std::path::Path;
 
-/// Writes the contents of selected files in a directory into a tagged output file (`tags_output.txt`).
+/// Summary of files included and skipped while generating tagged folder output.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct WriteFolderTagsSummary {
+    /// Number of matching files whose contents were successfully written.
+    pub files_written: usize,
+    /// Number of matching files skipped because their contents could not be read.
+    pub files_skipped: usize,
+    /// Number of skipped files that failed specifically because they were not valid UTF-8.
+    pub skipped_non_utf8_files: usize,
+}
+
+/// Writes the contents of selected files in a directory into a tagged output file.
 ///
 /// # Purpose
 /// Collects all files matching specific extensions from a given directory, optionally recursively,
-/// and writes each file’s contents into `tags_output.txt`, wrapped in an XML-style tag that corresponds
+/// and writes each file’s contents into `output_path`, wrapped in an XML-style tag that corresponds
 /// to its relative path.
 ///
 /// # Parameters
@@ -45,6 +56,7 @@ use std::path::Path;
 /// - `valid_exts`: List of allowed file extensions (e.g., `["rs", "md"]`) — case-sensitive and without dots.
 /// - `recursive`: If `true`, traverses subdirectories. If `false`, only scans the top-level directory.
 /// - `ignored_folders`: List of folder names (case-insensitive) to skip during recursive traversal (e.g., `["target", ".git"]`).
+/// - `output_path`: File to create or overwrite with tagged output.
 ///
 /// # Output Format
 /// Each file is wrapped in tags representing its relative path:
@@ -68,7 +80,7 @@ use std::path::Path;
 /// # Errors
 /// Returns `Err(std::io::Error)` if:
 /// - The directory or any file fails to open/read.
-/// - The output file (`tags_output.txt`) cannot be created or written.
+/// - The output file cannot be created or written.
 ///
 /// # Panics
 /// This function does **not** panic.
@@ -82,40 +94,37 @@ use std::path::Path;
 /// # Example
 /// ```rust
 /// let dir = Path::new("src");
-/// let exts = &["rs", "toml"];
+/// let exts = vec!["rs".to_string(), "toml".to_string()];
 /// let ignored = vec!["target".to_string(), ".git".to_string()];
-/// write_folder_tags(dir, exts, true, &ignored)?;
+/// let output_path = Path::new("tags_output.txt");
+/// write_folder_tags(dir, &exts, true, &ignored, output_path)?;
 /// ```
 pub fn write_folder_tags(
     dir: &Path,
-    valid_exts: &[&str],
+    valid_exts: &[String],
     recursive: bool,
     ignored_folders: &[String],
-) -> std::io::Result<()> {
-    let mut output = File::create("tags_output.txt")?;
+    output_path: &Path,
+) -> std::io::Result<WriteFolderTagsSummary> {
+    let mut output = File::create(output_path)?;
+    let mut summary = WriteFolderTagsSummary::default();
 
     if recursive {
-        write_folder_tags_recursive(dir, dir, valid_exts, &mut output, ignored_folders)?;
+        write_folder_tags_recursive(
+            dir,
+            dir,
+            valid_exts,
+            &mut output,
+            ignored_folders,
+            &mut summary,
+        )?;
     } else {
         for entry in read_dir(dir)? {
             let entry = entry?;
             let path = entry.path();
 
             if path.is_file() && is_human_readable(&path, valid_exts) {
-                if let Ok(relative_path) = path.strip_prefix(dir) {
-                    if let Some(rel_str) = relative_path.to_str() {
-                    match std::fs::read_to_string(&path) {
-                        Ok(contents) => {
-                            writeln!(output, "<{}>", rel_str)?;
-                            writeln!(output, "{}", contents)?;
-                            writeln!(output, "</{}>\n", rel_str)?;
-                        }
-                        Err(e) => {
-                            eprintln!("⚠️ Skipping {:?}: {}", path, e);
-                        }
-                    }
-                    }
-                }
+                write_tagged_file(dir, &path, &mut output, &mut summary)?;
             }
         }
     }
@@ -129,7 +138,7 @@ pub fn write_folder_tags(
         "* Under text under [Additional Commands] should be read very carefully and followed absolutely"
     )?;
 
-    Ok(())
+    Ok(summary)
 }
 
 /// Determines whether a file should be processed based on its extension.
@@ -140,7 +149,7 @@ pub fn write_folder_tags(
 ///
 /// # Parameters
 /// - `path`: A reference to the [`Path`] representing the file to evaluate.
-/// - `valid_exts`: A slice of valid file extensions (`&[&str]`), such as `["rs", "json", "toml"]`.
+/// - `valid_exts`: A slice of valid file extensions (`&[String]`), such as `["rs", "json", "toml"]`.
 ///   Extensions **must not** include leading dots (e.g., `"rs"`, not `".rs"`).
 ///
 /// # Returns
@@ -170,27 +179,56 @@ pub fn write_folder_tags(
 /// # Example
 /// ```rust
 /// let path = Path::new("src/main.rs");
-/// assert!(is_human_readable(path, &["rs", "txt"]));
+/// assert!(is_human_readable(path, &["rs".to_string(), "txt".to_string()]));
 ///
 /// let path = Path::new("README");
-/// assert!(!is_human_readable(path, &["md"])); // has no extension
+/// assert!(!is_human_readable(path, &["md".to_string()])); // has no extension
 /// ```
 ///
 /// # Future Enhancements
 /// - Optionally support case-insensitive matching.
 /// - Add content-based filtering (e.g., UTF-8 check or printable character ratio).
-fn is_human_readable(path: &Path, valid_exts: &[&str]) -> bool {
+fn is_human_readable(path: &Path, valid_exts: &[String]) -> bool {
     if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-        return valid_exts.contains(&ext);
+        return valid_exts.iter().any(|valid_ext| valid_ext == ext);
     }
     false
+}
+
+fn write_tagged_file(
+    root_dir: &Path,
+    path: &Path,
+    output: &mut File,
+    summary: &mut WriteFolderTagsSummary,
+) -> std::io::Result<()> {
+    if let Ok(relative_path) = path.strip_prefix(root_dir) {
+        if let Some(rel_str) = relative_path.to_str() {
+            match std::fs::read_to_string(path) {
+                Ok(contents) => {
+                    writeln!(output, "<{}>", rel_str)?;
+                    writeln!(output, "{}", contents)?;
+                    writeln!(output, "</{}>\n", rel_str)?;
+                    summary.files_written += 1;
+                }
+                Err(e) => {
+                    summary.files_skipped += 1;
+                    if e.kind() == ErrorKind::InvalidData {
+                        summary.skipped_non_utf8_files += 1;
+                    }
+                    eprintln!("⚠️ Skipping {:?}: {}", path, e);
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Appends a block of custom user-provided text to the end of the output file,
 /// under a `[Additional Commands]` header.
 ///
 /// # Purpose
-/// Allows users to supplement the main output (`tags_output.txt`) with additional
+/// Allows users to supplement a tagged output file with additional
 /// instructions, prompts, or commands that should be interpreted after the code sections.
 ///
 /// # Parameters
@@ -231,7 +269,7 @@ fn is_human_readable(path: &Path, valid_exts: &[&str]) -> bool {
 /// ```
 ///
 /// # See Also
-/// - [`write_folder_tags`]: Main output function that creates the initial `tags_output.txt`.
+/// - [`write_folder_tags`]: Main output function that creates the initial tagged output file.
 /// - [`copy_to_clipboard`]: Can be used after appending to share the result.
 pub fn append_additional_commands(
     file_path: &str,
@@ -250,13 +288,13 @@ pub fn append_additional_commands(
 ///
 /// # Purpose
 /// Processes all files with specified extensions within a directory tree, skipping ignored or hidden folders,
-/// and outputs their contents to a single file (`tags_output.txt`) with clear path-based XML tags.
+/// and outputs their contents to the caller-provided file with clear path-based XML tags.
 ///
 /// # Parameters
 /// - `root_dir`: The root directory of the traversal, used to compute relative paths for output tags.
 /// - `dir`: The current directory being visited (initially the same as `root_dir`).
-/// - `valid_exts`: List of file extensions (`&[&str]`) that are allowed (e.g., `["rs", "json"]`).
-/// - `output`: A mutable reference to the output file (typically `tags_output.txt`).
+/// - `valid_exts`: List of file extensions (`&[String]`) that are allowed (e.g., `["rs", "json"]`).
+/// - `output`: A mutable reference to the output file.
 /// - `ignored_folders`: A list of folder names (case-insensitive) to skip during traversal
 ///   (e.g., `[".git", "target"]`).
 ///
@@ -294,7 +332,9 @@ pub fn append_additional_commands(
 /// let root = Path::new("src");
 /// let mut output = File::create("tags_output.txt")?;
 /// let ignored = vec!["target".to_string(), ".git".to_string()];
-/// write_folder_tags_recursive(root, root, &["rs"], &mut output, &ignored)?;
+/// let valid_exts = vec!["rs".to_string()];
+/// let mut summary = WriteFolderTagsSummary::default();
+/// write_folder_tags_recursive(root, root, &valid_exts, &mut output, &ignored, &mut summary)?;
 /// ```
 ///
 /// # See Also
@@ -303,9 +343,10 @@ pub fn append_additional_commands(
 fn write_folder_tags_recursive(
     root_dir: &Path,
     dir: &Path,
-    valid_exts: &[&str],
+    valid_exts: &[String],
     output: &mut File,
     ignored_folders: &[String],
+    summary: &mut WriteFolderTagsSummary,
 ) -> std::io::Result<()> {
     for entry in read_dir(dir)? {
         let entry = entry?;
@@ -313,28 +354,144 @@ fn write_folder_tags_recursive(
 
         if path.is_dir() {
             if let Some(folder_name) = path.file_name().and_then(|n| n.to_str()) {
-                let folder_name = folder_name.to_lowercase();
-                if ignored_folders.contains(&folder_name) || folder_name.starts_with('.') {
+                if ignored_folders
+                    .iter()
+                    .any(|ignored| ignored.eq_ignore_ascii_case(folder_name))
+                    || folder_name.starts_with('.')
+                {
                     continue;
                 }
             }
-            write_folder_tags_recursive(root_dir, &path, valid_exts, output, ignored_folders)?;
+            write_folder_tags_recursive(
+                root_dir,
+                &path,
+                valid_exts,
+                output,
+                ignored_folders,
+                summary,
+            )?;
         } else if path.is_file() && is_human_readable(&path, valid_exts) {
-            if let Ok(relative_path) = path.strip_prefix(root_dir) {
-                if let Some(rel_str) = relative_path.to_str() {
-                    match std::fs::read_to_string(&path) {
-                        Ok(contents) => {
-                            writeln!(output, "<{}>", rel_str)?;
-                            writeln!(output, "{}", contents)?;
-                            writeln!(output, "</{}>\n", rel_str)?;
-                        }
-                        Err(e) => {
-                            eprintln!("⚠️ Skipping {:?}: {}", path, e);
-                        }
-                    }
-                }
-            }
+            write_tagged_file(root_dir, &path, output, summary)?;
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn valid_exts() -> Vec<String> {
+        vec!["rs".to_string()]
+    }
+
+    fn ignored_folders() -> Vec<String> {
+        vec!["target".to_string(), ".git".to_string()]
+    }
+
+    fn tag_for(relative_path: impl AsRef<Path>) -> String {
+        relative_path.as_ref().to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn custom_output_path_creates_requested_file() -> std::io::Result<()> {
+        let temp = tempdir()?;
+        let root = temp.path();
+        fs::write(root.join("main.rs"), "fn main() {}")?;
+        let output_path = root.join("custom_output.txt");
+
+        let summary =
+            write_folder_tags(root, &valid_exts(), false, &ignored_folders(), &output_path)?;
+
+        assert!(output_path.exists());
+        assert_eq!(summary.files_written, 1);
+        let output = fs::read_to_string(output_path)?;
+        assert!(output.contains("<main.rs>"));
+        assert!(output.contains("fn main() {}"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn tags_output_txt_is_not_created_for_different_output_path() -> std::io::Result<()> {
+        let temp = tempdir()?;
+        let root = temp.path();
+        fs::write(root.join("main.rs"), "fn main() {}")?;
+        let output_path = root.join("requested_output.txt");
+
+        write_folder_tags(root, &valid_exts(), false, &ignored_folders(), &output_path)?;
+
+        assert!(output_path.exists());
+        assert!(!root.join("tags_output.txt").exists());
+
+        Ok(())
+    }
+
+    #[test]
+    fn recursive_search_includes_nested_matching_files() -> std::io::Result<()> {
+        let temp = tempdir()?;
+        let root = temp.path();
+        fs::create_dir(root.join("nested"))?;
+        fs::write(root.join("nested").join("lib.rs"), "pub fn nested() {}")?;
+        let output_path = root.join("recursive_output.txt");
+
+        let summary =
+            write_folder_tags(root, &valid_exts(), true, &ignored_folders(), &output_path)?;
+
+        assert_eq!(summary.files_written, 1);
+        let output = fs::read_to_string(output_path)?;
+        let nested_tag = tag_for(Path::new("nested").join("lib.rs"));
+        assert!(output.contains(&format!("<{nested_tag}>")));
+        assert!(output.contains("pub fn nested() {}"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn non_recursive_search_excludes_nested_matching_files() -> std::io::Result<()> {
+        let temp = tempdir()?;
+        let root = temp.path();
+        fs::write(root.join("main.rs"), "fn main() {}")?;
+        fs::create_dir(root.join("nested"))?;
+        fs::write(root.join("nested").join("lib.rs"), "pub fn nested() {}")?;
+        let output_path = root.join("non_recursive_output.txt");
+
+        let summary =
+            write_folder_tags(root, &valid_exts(), false, &ignored_folders(), &output_path)?;
+
+        assert_eq!(summary.files_written, 1);
+        let output = fs::read_to_string(output_path)?;
+        assert!(output.contains("<main.rs>"));
+        assert!(!output.contains("pub fn nested() {}"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn ignored_folders_are_skipped_during_recursive_search() -> std::io::Result<()> {
+        let temp = tempdir()?;
+        let root = temp.path();
+        fs::write(root.join("main.rs"), "fn main() {}")?;
+        fs::create_dir(root.join("target"))?;
+        fs::write(
+            root.join("target").join("generated.rs"),
+            "pub fn target() {}",
+        )?;
+        fs::create_dir(root.join(".git"))?;
+        fs::write(root.join(".git").join("ignored.rs"), "pub fn git() {}")?;
+        let output_path = root.join("ignored_output.txt");
+
+        let summary =
+            write_folder_tags(root, &valid_exts(), true, &ignored_folders(), &output_path)?;
+
+        assert_eq!(summary.files_written, 1);
+        let output = fs::read_to_string(output_path)?;
+        assert!(output.contains("fn main() {}"));
+        assert!(!output.contains("pub fn target() {}"));
+        assert!(!output.contains("pub fn git() {}"));
+
+        Ok(())
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ use crate::utils::{copy_to_clipboard, get_cursor_position};
 
 use eframe::egui;
 use rfd::{MessageButtons, MessageDialog, MessageDialogResult, MessageLevel};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[cfg(windows)]
 const OPEN_COMMAND: &str = "notepad";
@@ -124,16 +124,21 @@ fn main() {
         std::process::exit(0);
     };
 
-    let valid_exts: Vec<&str> = group.extensions.iter().map(String::as_str).collect();
-
     let ignored_folders: Vec<String> = ignored_folders
         .lines()
         .map(|s| s.trim().to_lowercase())
         .filter(|s| !s.is_empty())
         .collect();
 
-    if let Err(e) = write_folder_tags(&dir, &valid_exts, enable_recursive_search, &ignored_folders)
-    {
+    let output_path = Path::new("tags_output.txt");
+
+    if let Err(e) = write_folder_tags(
+        &dir,
+        &group.extensions,
+        enable_recursive_search,
+        &ignored_folders,
+        output_path,
+    ) {
         eprintln!("❌ ERROR: Could not write folder tags: {}", e);
         std::process::exit(1);
     }
@@ -152,8 +157,10 @@ fn main() {
         combined_additional.push('\n');
     }
 
+    let output_path_string = output_path.to_string_lossy();
+
     if !combined_additional.trim().is_empty() {
-        if let Err(e) = append_additional_commands("tags_output.txt", &combined_additional) {
+        if let Err(e) = append_additional_commands(&output_path_string, &combined_additional) {
             eprintln!(
                 "❌ ERROR: Could not append combined additional commands: {}",
                 e
@@ -162,23 +169,23 @@ fn main() {
     }
 
     if enable_clipboard_copy {
-        if let Err(e) = copy_to_clipboard("tags_output.txt") {
+        if let Err(e) = copy_to_clipboard(&output_path_string) {
             eprintln!("❌ ERROR: Could not copy to clipboard: {}", e);
         }
     } else {
         let result = MessageDialog::new()
             .set_title("Open Output File?")
-            .set_description("Would you like to open the generated tags_output.txt file?")
+            .set_description("Would you like to open the generated output file?")
             .set_buttons(MessageButtons::YesNo)
             .set_level(MessageLevel::Info)
             .show();
 
         if result == MessageDialogResult::Yes {
             if let Err(e) = std::process::Command::new(OPEN_COMMAND)
-                .arg("tags_output.txt")
+                .arg(output_path)
                 .spawn()
             {
-                eprintln!("❌ ERROR: Failed to open tags_output.txt: {}", e);
+                eprintln!("❌ ERROR: Failed to open output file: {}", e);
             }
         }
     }


### PR DESCRIPTION
### Motivation

- Remove the hard-coded `tags_output.txt` output filename so callers can choose the output path. 
- Provide a machine-readable summary of how many files were written or skipped during generation for future CLI/GUI integration.

### Description

- Add a public `WriteFolderTagsSummary` struct with `files_written`, `files_skipped`, and `skipped_non_utf8_files` counters to `src/file_ops.rs`.
- Change `write_folder_tags` to accept `valid_exts: &[String]`, `output_path: &Path` and return `std::io::Result<WriteFolderTagsSummary>`, and replace `File::create("tags_output.txt")` with `File::create(output_path)`.
- Update `is_human_readable` to accept `valid_exts: &[String]` and preserve exact extension matching semantics.
- Add `write_tagged_file` helper and update `write_folder_tags_recursive` to accept and update a `WriteFolderTagsSummary` reference so recursive and non-recursive flows both accumulate counts (counting successful writes, read failures, and invalid-UTF8 skips) while preserving existing XML tag and footer formatting.
- Update `src/main.rs` to call the new API with `Path::new("tags_output.txt")` to preserve current behavior and to use the chosen path for appending, clipboard copy and open operations.
- Add unit tests in `src/file_ops.rs` (tempfile-backed) to verify custom output path creation, that `tags_output.txt` is not created when a different path is passed, recursive inclusion of nested files, non-recursive exclusion of nested files, and that ignored folders are skipped.
- Add `tempfile = "3"` under `[dev-dependencies]` in `Cargo.toml`.

### Testing

- Ran `cargo test`; all new and existing tests passed (5 tests running for the file ops behaviors). 
- Ran `rustfmt --check` on `src/file_ops.rs` (check succeeded).
- Performed `git diff --check` style checks (no issues reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20b76dcf7c8332b844e4e4ee7bc1c3)