### PR TITLE
Add CLI startup routing

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,378 @@
+use crate::filetypes::{find_filetype_group, format_available_filetype_groups, FileTypeGroup};
+use crate::generation::TagGenerationRequest;
+use crate::presets::PresetCommand;
+use clap::{Args, Parser, Subcommand};
+use std::collections::HashSet;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Parser)]
+#[command(name = "code-file-wrapper")]
+#[command(about = "Wrap selected project files in tagged context output")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Launch the graphical interface.
+    Gui,
+    /// Generate output from command-line arguments.
+    Run(RunArgs),
+    /// Print available file type groups from filetypes.json.
+    ListFileTypes,
+}
+
+#[derive(Debug, Args)]
+pub struct RunArgs {
+    #[arg(long)]
+    pub dir: PathBuf,
+    #[arg(long = "file-type")]
+    pub file_type: Option<String>,
+    #[arg(long = "ext")]
+    pub extensions: Vec<String>,
+    #[arg(long)]
+    pub recursive: bool,
+    #[arg(long = "ignore")]
+    pub ignored_folders: Vec<String>,
+    #[arg(long, default_value = "tags_output.txt")]
+    pub output: PathBuf,
+    #[arg(long)]
+    pub copy: bool,
+    #[arg(long)]
+    pub open: bool,
+    #[arg(long = "preset")]
+    pub presets: Vec<String>,
+    #[arg(long = "additional")]
+    pub additional_commands: Option<String>,
+    #[arg(long = "additional-file")]
+    pub additional_commands_file: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BuiltRunRequest {
+    pub request: TagGenerationRequest,
+    pub extensions_used: Vec<String>,
+}
+
+pub fn build_run_request(
+    args: RunArgs,
+    file_type_groups: &[FileTypeGroup],
+    presets: &[PresetCommand],
+) -> Result<BuiltRunRequest, String> {
+    let extensions = resolve_extensions(&args, file_type_groups)?;
+    let preset_texts = resolve_presets(&args.presets, presets)?;
+    let additional_commands = resolve_additional_commands(
+        args.additional_commands_file.as_ref(),
+        args.additional_commands.as_deref(),
+    )?;
+
+    Ok(BuiltRunRequest {
+        extensions_used: extensions.clone(),
+        request: TagGenerationRequest {
+            root_dir: args.dir,
+            extensions,
+            recursive: args.recursive,
+            ignored_folders: args.ignored_folders,
+            output_path: args.output,
+            additional_commands,
+            preset_texts,
+            copy_to_clipboard: args.copy,
+            open_after: args.open,
+        },
+    })
+}
+
+fn resolve_extensions(
+    args: &RunArgs,
+    file_type_groups: &[FileTypeGroup],
+) -> Result<Vec<String>, String> {
+    let mut extensions = Vec::new();
+
+    if let Some(file_type) = args.file_type.as_deref() {
+        let group = find_filetype_group(file_type_groups, file_type).ok_or_else(|| {
+            format!(
+                "Unknown file type group '{file_type}'. Available file type groups:\n{}",
+                format_available_filetype_groups(file_type_groups)
+            )
+        })?;
+        extensions.extend(
+            group
+                .extensions
+                .iter()
+                .map(|extension| normalize_extension(extension)),
+        );
+    }
+
+    extensions.extend(
+        args.extensions
+            .iter()
+            .map(|extension| normalize_extension(extension)),
+    );
+
+    extensions.retain(|extension| !extension.is_empty());
+    deduplicate_preserving_order(&mut extensions);
+
+    if extensions.is_empty() {
+        return Err(
+            "No extensions selected. Provide --file-type <group> or one or more --ext <extension> values."
+                .to_string(),
+        );
+    }
+
+    Ok(extensions)
+}
+
+fn normalize_extension(extension: &str) -> String {
+    extension.trim().trim_start_matches('.').to_string()
+}
+
+fn deduplicate_preserving_order(values: &mut Vec<String>) {
+    let mut seen = HashSet::new();
+    values.retain(|value| seen.insert(value.clone()));
+}
+
+fn resolve_presets(
+    requested_presets: &[String],
+    presets: &[PresetCommand],
+) -> Result<Vec<String>, String> {
+    requested_presets
+        .iter()
+        .map(|requested_name| {
+            presets
+                .iter()
+                .find(|preset| preset.name.eq_ignore_ascii_case(requested_name))
+                .map(|preset| preset.text.clone())
+                .ok_or_else(|| {
+                    format!(
+                        "Unknown preset '{requested_name}'. Available presets:\n{}",
+                        format_available_presets(presets)
+                    )
+                })
+        })
+        .collect()
+}
+
+fn format_available_presets(presets: &[PresetCommand]) -> String {
+    presets
+        .iter()
+        .map(|preset| format!("- {}", preset.name))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn resolve_additional_commands(
+    additional_commands_file: Option<&PathBuf>,
+    additional_commands: Option<&str>,
+) -> Result<String, String> {
+    let file_content = additional_commands_file
+        .map(|path| {
+            fs::read_to_string(path).map_err(|error| {
+                format!(
+                    "Failed to read additional commands file '{}': {error}",
+                    path.display()
+                )
+            })
+        })
+        .transpose()?;
+
+    let mut parts = Vec::new();
+    if let Some(file_content) = file_content {
+        if !file_content.trim().is_empty() {
+            parts.push(file_content);
+        }
+    }
+    if let Some(additional_commands) = additional_commands {
+        if !additional_commands.trim().is_empty() {
+            parts.push(additional_commands.to_string());
+        }
+    }
+
+    Ok(parts.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use tempfile::tempdir;
+
+    fn rust_group() -> Vec<FileTypeGroup> {
+        vec![FileTypeGroup {
+            name: "Rust".to_string(),
+            extensions: vec!["rs".to_string()],
+        }]
+    }
+
+    #[test]
+    fn run_with_file_type_parses_correctly() {
+        let cli = Cli::try_parse_from([
+            "code-file-wrapper",
+            "run",
+            "--dir",
+            ".",
+            "--file-type",
+            "Rust",
+            "--recursive",
+            "--output",
+            "context.txt",
+        ])
+        .expect("CLI should parse");
+
+        let Some(Command::Run(args)) = cli.command else {
+            panic!("expected run command");
+        };
+
+        assert_eq!(args.dir, PathBuf::from("."));
+        assert_eq!(args.file_type.as_deref(), Some("Rust"));
+        assert!(args.recursive);
+        assert_eq!(args.output, PathBuf::from("context.txt"));
+    }
+
+    #[test]
+    fn repeated_ext_values_parse() {
+        let cli = Cli::try_parse_from([
+            "code-file-wrapper",
+            "run",
+            "--dir",
+            ".",
+            "--ext",
+            "rs",
+            "--ext",
+            "toml",
+            "--ext",
+            "md",
+        ])
+        .expect("CLI should parse");
+
+        let Some(Command::Run(args)) = cli.command else {
+            panic!("expected run command");
+        };
+
+        assert_eq!(args.extensions, vec!["rs", "toml", "md"]);
+    }
+
+    #[test]
+    fn repeated_ignore_values_parse() {
+        let cli = Cli::try_parse_from([
+            "code-file-wrapper",
+            "run",
+            "--dir",
+            ".",
+            "--ext",
+            "rs",
+            "--ignore",
+            "target",
+            "--ignore",
+            ".git",
+        ])
+        .expect("CLI should parse");
+
+        let Some(Command::Run(args)) = cli.command else {
+            panic!("expected run command");
+        };
+
+        assert_eq!(args.ignored_folders, vec!["target", ".git"]);
+    }
+
+    #[test]
+    fn no_arg_cli_has_no_command() {
+        let cli = Cli::try_parse_from(["code-file-wrapper"]).expect("CLI should parse");
+
+        assert!(cli.command.is_none());
+    }
+
+    #[test]
+    fn build_run_request_combines_and_deduplicates_extensions() {
+        let args = Cli::try_parse_from([
+            "code-file-wrapper",
+            "run",
+            "--dir",
+            ".",
+            "--file-type",
+            "Rust",
+            "--ext",
+            ".toml",
+            "--ext",
+            "rs",
+        ])
+        .expect("CLI should parse");
+        let Some(Command::Run(args)) = args.command else {
+            panic!("expected run command");
+        };
+
+        let built = build_run_request(args, &rust_group(), &[]).expect("request should build");
+
+        assert_eq!(built.extensions_used, vec!["rs", "toml"]);
+        assert_eq!(built.request.extensions, vec!["rs", "toml"]);
+    }
+
+    #[test]
+    fn build_run_request_requires_extensions() {
+        let args = Cli::try_parse_from(["code-file-wrapper", "run", "--dir", "."])
+            .expect("CLI should parse");
+        let Some(Command::Run(args)) = args.command else {
+            panic!("expected run command");
+        };
+
+        let error = build_run_request(args, &rust_group(), &[]).expect_err("expected error");
+
+        assert!(error.contains("Provide --file-type"));
+    }
+
+    #[test]
+    fn additional_file_content_precedes_inline_additional_commands() -> std::io::Result<()> {
+        let temp = tempdir()?;
+        let additional_path = temp.path().join("additional.txt");
+        fs::write(&additional_path, "from file")?;
+        let args = Cli::try_parse_from([
+            "code-file-wrapper",
+            "run",
+            "--dir",
+            ".",
+            "--ext",
+            "rs",
+            "--additional-file",
+            additional_path.to_str().expect("path is UTF-8"),
+            "--additional",
+            "inline",
+        ])
+        .expect("CLI should parse");
+        let Some(Command::Run(args)) = args.command else {
+            panic!("expected run command");
+        };
+
+        let built = build_run_request(args, &rust_group(), &[]).expect("request should build");
+
+        assert_eq!(built.request.additional_commands, "from file\ninline");
+        Ok(())
+    }
+
+    #[test]
+    fn unknown_preset_lists_available_presets() {
+        let args = Cli::try_parse_from([
+            "code-file-wrapper",
+            "run",
+            "--dir",
+            ".",
+            "--ext",
+            "rs",
+            "--preset",
+            "missing",
+        ])
+        .expect("CLI should parse");
+        let Some(Command::Run(args)) = args.command else {
+            panic!("expected run command");
+        };
+        let presets = vec![PresetCommand {
+            name: "Known".to_string(),
+            text: "preset text".to_string(),
+        }];
+
+        let error = build_run_request(args, &rust_group(), &presets).expect_err("expected error");
+
+        assert!(error.contains("Unknown preset 'missing'"));
+        assert!(error.contains("- Known"));
+    }
+}

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -23,7 +23,7 @@
 //! - Uses `eframe::run_native` to block execution until the user completes the selection.
 //! - Updates shared mutable state passed by reference from `main.rs`.
 
-use crate::filetypes::{get_filetypes, save_filetypes, FileTypeGroup};
+use crate::filetypes::{save_filetypes, FileTypeGroup};
 use crate::presets::save_presets;
 use crate::presets::{get_presets, PresetCommand};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@
 //! - Generates or updates `tags_output.txt`.
 
 #![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
+mod cli;
 mod file_ops;
 mod filetypes;
 mod generation;
@@ -29,11 +30,14 @@ mod gui;
 mod presets;
 mod utils;
 
+use crate::cli::{build_run_request, Cli, Command};
 use crate::filetypes::{get_filetypes, FileTypeGroup};
-use crate::generation::{generate_tag_output, TagGenerationRequest};
+use crate::generation::{generate_tag_output, GenerationSummary, TagGenerationRequest};
 use crate::gui::ModeSelector;
+use crate::presets::get_presets;
 use crate::utils::get_cursor_position;
 
+use clap::Parser;
 use eframe::egui;
 use rfd::{MessageButtons, MessageDialog, MessageDialogResult, MessageLevel};
 use std::path::PathBuf;
@@ -45,53 +49,47 @@ const OPEN_COMMAND: &str = "xdg-open";
 
 /// The main entry point of the application.
 ///
-/// # Purpose
-/// Coordinates the entire program flow, from GUI input to file processing and clipboard interaction.
-///
-/// # Parameters
-/// None.
-///
-/// # Behavior
-/// - Loads initial file type groups from disk (or uses defaults).
-/// - Displays the GUI to collect user input (directory, file type, recursion, etc.).
-/// - Validates the user input and exits with a warning if invalid.
-/// - Calls [`generate_tag_output`] to process matching files in the selected directory.
-/// - Supplies user-entered and preset commands to the shared generation layer.
-/// - Prompts to open the generated file when clipboard copy is disabled.
-///
-/// # Panics
-/// - Does not explicitly panic, but will `exit(1)` if:
-///   - The selected path is not a directory.
-///   - `tags_output.txt` could not be written.
-///
-/// # Errors
-/// - Errors are logged to `stderr`, including:
-///   - Invalid directory selection.
-///   - File write failures.
-///   - Clipboard failures or inability to launch Notepad.
-///
-/// # Side Effects
-/// - Overwrites or creates `tags_output.txt` in the working directory.
-/// - The generation layer optionally modifies the system clipboard.
-/// - Optionally spawns the platform file opener to view the output.
-///
-/// # Notes
-/// - Runs on Windows and Linux (clipboard and dialog support are available).
-/// - Relies on GUI state to be collected before file operations.
-/// - Uses structured JSON files for storing user presets and file type modes.
-/// - Always exits cleanly via `std::process::exit(0)` or `exit(1)`.
-///
-/// # Example
-/// ```rust
-/// fn main() {
-///     // Triggers GUI, processes files, writes output, etc.
-/// }
-/// ```
-///
-/// # Related
-/// - [`mode_selection_gui`] – Launches the GUI and gathers input.
-/// - [`generate_tag_output`] – Handles shared tagged output generation.
+/// Parses command-line arguments first. With no subcommand, or with `gui`, it
+/// launches the existing graphical flow. Other subcommands run non-interactive
+/// CLI tasks and exit with an appropriate status code.
 fn main() {
+    let cli = Cli::parse();
+
+    match cli.command {
+        None | Some(Command::Gui) => run_gui_flow(),
+        Some(Command::ListFileTypes) => list_file_types(),
+        Some(Command::Run(args)) => {
+            let file_type_groups = get_filetypes();
+            let presets = get_presets();
+            let built = match build_run_request(args, &file_type_groups, &presets) {
+                Ok(built) => built,
+                Err(error) => {
+                    eprintln!("❌ ERROR: {error}");
+                    std::process::exit(1);
+                }
+            };
+
+            let open_after = built.request.open_after;
+            let extensions_used = built.extensions_used.clone();
+            let summary = match generate_tag_output(built.request) {
+                Ok(summary) => summary,
+                Err(e) => {
+                    eprintln!("❌ ERROR: Could not generate tag output: {}", e);
+                    std::process::exit(1);
+                }
+            };
+
+            if open_after {
+                open_output_file(&summary);
+            }
+
+            print_cli_summary(&summary, &extensions_used);
+            std::process::exit(0);
+        }
+    }
+}
+
+fn run_gui_flow() {
     let initial_file_type_groups = get_filetypes();
     let cursor_position = get_cursor_position();
 
@@ -154,16 +152,36 @@ fn main() {
             .show();
 
         if result == MessageDialogResult::Yes {
-            if let Err(e) = std::process::Command::new(OPEN_COMMAND)
-                .arg(&summary.output_path)
-                .spawn()
-            {
-                eprintln!("❌ ERROR: Failed to open output file: {}", e);
-            }
+            open_output_file(&summary);
         }
     }
 
     std::process::exit(0);
+}
+
+fn list_file_types() {
+    for group in get_filetypes() {
+        println!("{}: {}", group.name, group.extensions.join(", "));
+    }
+}
+
+fn print_cli_summary(summary: &GenerationSummary, extensions_used: &[String]) {
+    println!("✅ Generation complete.");
+    println!("Output path: {}", summary.output_path.display());
+    println!("Files included: {}", summary.files_written);
+    println!("Files skipped: {}", summary.files_skipped);
+    println!("Non-UTF8 files skipped: {}", summary.skipped_non_utf8_files);
+    println!("Recursive: {}", summary.recursive);
+    println!("Extensions used: {}", extensions_used.join(", "));
+}
+
+fn open_output_file(summary: &GenerationSummary) {
+    if let Err(e) = std::process::Command::new(OPEN_COMMAND)
+        .arg(&summary.output_path)
+        .spawn()
+    {
+        eprintln!("❌ ERROR: Failed to open output file: {}", e);
+    }
 }
 
 /// Launches the graphical user interface and returns user selections for file processing.


### PR DESCRIPTION
### Motivation
- Provide a non-interactive CLI surface so the app can be invoked from scripts or terminals while keeping the existing GUI behavior as the default.
- Allow users to run generation from the command line with the same resolution rules as the GUI (file-type groups, presets, additional commands).

### Description
- Add a new `src/cli.rs` implementing a `clap`-based `Cli`, `Command` (with `Gui`, `Run`, `ListFileTypes`), and `RunArgs`, plus `build_run_request` to convert `RunArgs` into a `TagGenerationRequest` while resolving file-type groups, normalizing/deduplicating `--ext` values, resolving presets, and composing `--additional-file` then `--additional` deterministically.
- Route program startup in `src/main.rs` through `Cli::parse()` so that no-arg or `gui` still launch the GUI and `run`/`list-file-types` perform non-interactive operations and print a concise generation summary.
- Add unit tests in `src/cli.rs` for parsing and `RunArgs`→request conversion (including repeated `--ext`, repeated `--ignore`, no-arg parsing, extension deduplication, additional-file ordering, and unknown preset error messages).
- Remove an unused import in `src/gui.rs` and add helper CLI summary and utility helpers in `main` to print generation results and open the output when requested.

### Testing
- Ran `cargo test` and all unit tests passed (23 passed, 0 failed).
- Ran `cargo run -- list-file-types` which printed configured groups like `Rust: rs`, `JSON: json`, `Lua: lua` successfully.
- Performed an end-to-end CLI run: `cargo run -- run --dir <tmpdir> --ext .rs --recursive --output <tmpdir>/rust_context.txt` and verified the output file was created and the CLI printed a generation summary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20c057f178833289a02aa1a6834daf)