### PR TITLE
Allow GUI output path selection

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -30,7 +30,7 @@ use crate::presets::{get_presets, PresetCommand};
 use eframe::egui;
 use rfd::FileDialog;
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Holds the interactive state and logic for the main GUI window.
 ///
@@ -43,6 +43,7 @@ use std::path::PathBuf;
 /// - `modes`: All available file type modes (e.g., Rust, JSON).
 /// - `selected_mode`: Currently selected file type mode (shared mutable).
 /// - `enable_clipboard_copy`: Whether the clipboard should be updated after output is generated.
+/// - `output_path`: Path where the generated output file should be written.
 /// - `additional_commands`: Multiline string entered by the user to append to the output.
 /// - `selected_dir`: The selected folder path for file processing.
 /// - `preset_texts`: Output accumulator for selected presets (shared mutable).
@@ -67,6 +68,7 @@ pub struct ModeSelector<'a> {
     file_type_groups: &'a mut Vec<FileTypeGroup>,
     selected_type_index: &'a mut Option<usize>,
     enable_clipboard_copy: &'a mut bool,
+    output_path: &'a mut String,
     additional_commands: &'a mut String,
     selected_dir: &'a mut Option<PathBuf>,
     preset_texts: &'a mut Vec<String>,
@@ -88,6 +90,7 @@ impl<'a> ModeSelector<'a> {
         file_type_groups: &'a mut Vec<FileTypeGroup>,
         selected_type_index: &'a mut Option<usize>,
         enable_clipboard_copy: &'a mut bool,
+        output_path: &'a mut String,
         additional_commands: &'a mut String,
         selected_dir: &'a mut Option<PathBuf>,
         preset_texts: &'a mut Vec<String>,
@@ -103,6 +106,7 @@ impl<'a> ModeSelector<'a> {
             file_type_groups,
             selected_type_index,
             enable_clipboard_copy,
+            output_path,
             additional_commands,
             selected_dir,
             preset_texts,
@@ -118,6 +122,25 @@ impl<'a> ModeSelector<'a> {
             joined_extensions,
         }
     }
+}
+
+/// Validates a user-entered output path from the GUI.
+///
+/// Empty and whitespace-only input is rejected, as is any path that already
+/// exists as a directory. Relative filenames and absolute paths are accepted.
+pub fn validate_output_path_input(input: &str) -> Result<PathBuf, String> {
+    let trimmed = input.trim();
+
+    if trimmed.is_empty() {
+        return Err("Please enter an output file path.".to_string());
+    }
+
+    let path = Path::new(trimmed);
+    if path.is_dir() {
+        return Err("Output path must not be an existing directory.".to_string());
+    }
+
+    Ok(path.to_path_buf())
 }
 
 impl eframe::App for ModeSelector<'_> {
@@ -169,6 +192,7 @@ impl eframe::App for ModeSelector<'_> {
     ///   - `selected_dir`
     ///   - `selected_mode`
     ///   - `preset_texts`
+    ///   - `output_path`
     ///   - `additional_commands`
     ///   - `enable_clipboard_copy`
     ///   - `enable_recursive_search`
@@ -249,6 +273,14 @@ impl eframe::App for ModeSelector<'_> {
                 self.enable_recursive_search,
                 "Enable recursive directory search",
             );
+
+            ui.horizontal(|ui| {
+                ui.label("Output File:");
+                ui.add(
+                    egui::TextEdit::singleline(self.output_path)
+                        .desired_width(ui.available_width()),
+                );
+            });
 
             if *self.enable_recursive_search {
                 ui.group(|ui| {
@@ -338,7 +370,10 @@ impl eframe::App for ModeSelector<'_> {
                     self.warning_message = "⚠️ Please select a directory before proceeding!".into();
                 } else if self.selected_type_index.is_none() {
                     self.warning_message = "⚠️ Please select a file type before proceeding!".into();
+                } else if let Err(message) = validate_output_path_input(self.output_path) {
+                    self.warning_message = format!("⚠️ {message}");
                 } else {
+                    *self.output_path = self.output_path.trim().to_string();
                     // Push selected preset text
                     for preset in &self.presets {
                         if self.selected_presets.contains(&preset.name) {
@@ -552,5 +587,54 @@ impl eframe::App for ModeSelector<'_> {
                 }
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_output_path_input;
+    use tempfile::tempdir;
+
+    #[test]
+    fn validate_output_path_rejects_empty_input() {
+        let error = validate_output_path_input("").expect_err("expected error");
+
+        assert!(error.contains("output file path"));
+    }
+
+    #[test]
+    fn validate_output_path_rejects_whitespace_only_input() {
+        let error = validate_output_path_input(" \n\t  ").expect_err("expected error");
+
+        assert!(error.contains("output file path"));
+    }
+
+    #[test]
+    fn validate_output_path_accepts_relative_filename() {
+        let path = validate_output_path_input("mouse_mover_context.txt").expect("valid path");
+
+        assert_eq!(path, std::path::PathBuf::from("mouse_mover_context.txt"));
+    }
+
+    #[test]
+    fn validate_output_path_accepts_absolute_temp_path() -> std::io::Result<()> {
+        let temp = tempdir()?;
+        let output_path = temp.path().join("nested-output.txt");
+
+        let path = validate_output_path_input(&output_path.to_string_lossy()).expect("valid path");
+
+        assert_eq!(path, output_path);
+        Ok(())
+    }
+
+    #[test]
+    fn validate_output_path_rejects_existing_directory_path() -> std::io::Result<()> {
+        let temp = tempdir()?;
+
+        let error =
+            validate_output_path_input(&temp.path().to_string_lossy()).expect_err("expected error");
+
+        assert!(error.contains("existing directory"));
+        Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@
 //! - Relies on `presets` for saved preset data.
 //!
 //! # Output
-//! - Generates or updates `tags_output.txt`.
+//! - Generates or updates the selected output file.
 
 #![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
 mod cli;
@@ -98,6 +98,7 @@ fn run_gui_flow() {
         selected_dir,
         selected_type_index,
         enable_clipboard_copy,
+        output_path,
         additional_commands,
         preset_texts,
         enable_recursive_search,
@@ -128,7 +129,7 @@ fn run_gui_flow() {
         extensions: group.extensions.clone(),
         recursive: enable_recursive_search,
         ignored_folders,
-        output_path: PathBuf::from("tags_output.txt"),
+        output_path: PathBuf::from(output_path),
         additional_commands,
         preset_texts,
         copy_to_clipboard: enable_clipboard_copy,
@@ -146,7 +147,10 @@ fn run_gui_flow() {
     if open_after {
         let result = MessageDialog::new()
             .set_title("Open Output File?")
-            .set_description("Would you like to open the generated output file?")
+            .set_description(format!(
+                "Would you like to open the generated output file?\n\n{}",
+                summary.output_path.display()
+            ))
             .set_buttons(MessageButtons::YesNo)
             .set_level(MessageLevel::Info)
             .show();
@@ -191,6 +195,7 @@ fn open_output_file(summary: &GenerationSummary) {
 /// - Target directory
 /// - File type group (by extension)
 /// - Whether to copy results to the clipboard
+/// - Output file path
 /// - Additional instructional or preset commands
 /// - Recursive folder scanning options and ignored folders
 ///
@@ -204,6 +209,7 @@ fn open_output_file(summary: &GenerationSummary) {
 /// - `Option<PathBuf>`: The selected directory path.
 /// - `Option<usize>`: Index of the selected file type group, or `None` if not selected.
 /// - `bool`: Whether to copy output to the clipboard after generation.
+/// - `String`: Output file path.
 /// - `String`: Custom text commands to be appended to the output file.
 /// - `Vec<String>`: Collected preset command texts selected by the user.
 /// - `bool`: Whether recursive directory search is enabled.
@@ -230,7 +236,7 @@ fn open_output_file(summary: &GenerationSummary) {
 /// ```rust
 /// let groups = get_filetypes();
 /// let cursor = get_cursor_position();
-/// let (groups, dir, mode, clipboard, commands, presets, recursive, ignored) =
+/// let (groups, dir, mode, clipboard, output, commands, presets, recursive, ignored) =
 ///     mode_selection_gui(groups, cursor);
 /// ```
 ///
@@ -245,6 +251,7 @@ fn mode_selection_gui(
     Option<PathBuf>, // selected_dir
     Option<usize>,   // selected file type group index
     bool,            // clipboard
+    String,          // output path
     String,          // additional commands
     Vec<String>,     // preset texts
     bool,            // recursive
@@ -253,6 +260,7 @@ fn mode_selection_gui(
     let mut local_file_type_groups = file_type_groups;
     let mut selected_mode: Option<usize> = None;
     let mut enable_clipboard_copy = false;
+    let mut output_path = "tags_output.txt".to_string();
     let mut additional_commands = String::new();
     let mut selected_dir: Option<PathBuf> = None;
     let mut preset_texts = Vec::new();
@@ -266,6 +274,7 @@ fn mode_selection_gui(
         &mut local_file_type_groups,
         &mut selected_mode,
         &mut enable_clipboard_copy,
+        &mut output_path,
         &mut additional_commands,
         &mut selected_dir,
         &mut preset_texts,
@@ -293,6 +302,7 @@ fn mode_selection_gui(
         selected_dir,
         selected_mode,
         enable_clipboard_copy,
+        output_path,
         additional_commands,
         preset_texts,
         enable_recursive_search,


### PR DESCRIPTION
### Motivation
- Provide a GUI control so users can choose the generated output file path instead of always using `tags_output.txt`.
- Validate user input early in the GUI to avoid generating output to invalid locations (empty input or an existing directory).

### Description
- Added a mutable `output_path: &'a mut String` field to `ModeSelector` and updated `ModeSelector::new` to accept and store it.
- Rendered an `Output File:` single-line input (`egui::TextEdit::singleline`) in the GUI near the recursive/clipboard options and integrated trimming into the OK flow.
- Implemented `validate_output_path_input(input: &str) -> Result<PathBuf, String>` in `src/gui.rs` and wired it into the OK button validation to reject empty/whitespace input and existing-directory targets while allowing relative and absolute paths.
- In `src/main.rs`, initialized `let mut output_path = "tags_output.txt".to_string();` inside `mode_selection_gui`, threaded `output_path` through the GUI return tuple, and set `TagGenerationRequest.output_path` with `PathBuf::from(output_path)` when building the generation request.
- Updated the open-file dialog description to show the actual selected output path (`summary.output_path`) and relied on the existing generation/clipboard code which already uses `request.output_path`.
- Added unit tests for the new helper validating: empty, whitespace-only, relative filename (`mouse_mover_context.txt`), absolute temp path, and existing directory inputs (in `src/gui.rs`).

### Testing
- Ran `cargo test` and all tests passed: 28 passed, 0 failed; the new GUI helper tests and existing generation/file-op tests succeeded.
- Build emitted deprecation warnings for a couple of existing `egui` APIs but no test failures occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20c298f07c83328940d9d0ec4ec983)