### PR TITLE
Make Windows CLI output and errors visible (remove windows_subsystem)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ cargo build --release
 - Output is written to `tags_output.txt`  
 - Optionally copies output to your clipboard  
 
+### Windows CLI and GUI Tradeoff
+
+The Windows build uses the normal console subsystem so CLI output and errors are visible in PowerShell. This means commands such as `code-file-wrapper list-file-types` print their results normally, and invalid CLI invocations show errors with non-zero exit codes.
+
+The tradeoff is that launching the GUI build directly on Windows may show a console window alongside the graphical interface. A future two-binary design could provide `code-file-wrapper.exe` for CLI use and `code-file-wrapper-gui.exe` with `windows_subsystem = "windows"` for GUI-only launch without a console window.
+
 ---
 
 ## 📜 How It Works

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@
 //! # Output
 //! - Generates or updates the selected output file.
 
-#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
 mod cli;
 mod file_ops;
 mod filetypes;


### PR DESCRIPTION
### Motivation
- Ensure CLI stdout/stderr are visible on Windows (PowerShell) so commands and error paths produce visible output and non-zero exit codes, accepting the tradeoff that launching the GUI may show a console window.

### Description
- Removed the crate attribute `#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]` from `src/main.rs` and added a short explanation in `README.md` describing the Windows CLI/GUI tradeoff and a suggested future two-binary design (`code-file-wrapper.exe` and `code-file-wrapper-gui.exe`).

### Testing
- Ran automated checks and tests: `cargo check`, `cargo check --target x86_64-pc-windows-gnu`, `cargo run -- list-file-types`, executed `./target/debug/code-file-wrapper run --dir . --file-type DoesNotExist` to confirm visible error and non-zero exit, and `cargo test`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20c64aafa4833281a7a4102ef97cd3)