### PR TITLE
Add reusable run profiles

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,8 +20,25 @@ pub enum Command {
     Gui,
     /// Generate output from command-line arguments.
     Run(RunArgs),
+    /// Generate output from a saved profile.
+    RunProfile { name: String },
+    /// Print saved run profiles.
+    ListProfiles,
+    /// Delete a saved run profile.
+    DeleteProfile { name: String },
+    /// Save a reusable run profile from command-line arguments.
+    SaveProfile(SaveProfileArgs),
     /// Print available file type groups from filetypes.json.
     ListFileTypes,
+}
+
+#[derive(Debug, Args)]
+pub struct SaveProfileArgs {
+    pub name: String,
+    #[arg(long)]
+    pub force: bool,
+    #[command(flatten)]
+    pub run: RunArgs,
 }
 
 #[derive(Debug, Args)]
@@ -61,6 +78,7 @@ pub fn build_run_request(
     file_type_groups: &[FileTypeGroup],
     presets: &[PresetCommand],
 ) -> Result<BuiltRunRequest, String> {
+    validate_run_directory(&args.dir)?;
     let extensions = resolve_extensions(&args, file_type_groups)?;
     let preset_texts = resolve_presets(&args.presets, presets)?;
     let additional_commands = resolve_additional_commands(
@@ -82,6 +100,17 @@ pub fn build_run_request(
             open_after: args.open,
         },
     })
+}
+
+fn validate_run_directory(dir: &PathBuf) -> Result<(), String> {
+    if !dir.is_dir() {
+        return Err(format!(
+            "Directory '{}' does not exist or is not a folder.",
+            dir.display()
+        ));
+    }
+
+    Ok(())
 }
 
 fn resolve_extensions(
@@ -162,7 +191,7 @@ fn format_available_presets(presets: &[PresetCommand]) -> String {
         .join("\n")
 }
 
-fn resolve_additional_commands(
+pub(crate) fn resolve_additional_commands(
     additional_commands_file: Option<&PathBuf>,
     additional_commands: Option<&str>,
 ) -> Result<String, String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ mod filetypes;
 mod generation;
 mod gui;
 mod presets;
+mod profiles;
 mod utils;
 
 use crate::cli::{build_run_request, Cli, Command};
@@ -34,6 +35,10 @@ use crate::filetypes::{get_filetypes, FileTypeGroup};
 use crate::generation::{generate_tag_output, GenerationSummary, TagGenerationRequest};
 use crate::gui::ModeSelector;
 use crate::presets::get_presets;
+use crate::profiles::{
+    delete_profile, find_profile, load_profiles, profile_from_run_args, profile_to_run_request,
+    save_profile,
+};
 use crate::utils::get_cursor_position;
 
 use clap::Parser;
@@ -57,6 +62,40 @@ fn main() {
     match cli.command {
         None | Some(Command::Gui) => run_gui_flow(),
         Some(Command::ListFileTypes) => list_file_types(),
+        Some(Command::ListProfiles) => list_profiles(),
+        Some(Command::DeleteProfile { name }) => {
+            if let Err(error) = delete_profile(&name) {
+                eprintln!("❌ ERROR: {error}");
+                std::process::exit(1);
+            }
+            println!("✅ Deleted profile '{name}'.");
+            std::process::exit(0);
+        }
+        Some(Command::SaveProfile(args)) => {
+            let file_type_groups = get_filetypes();
+            let presets = get_presets();
+            let profile = match profile_from_run_args(args.name, args.run) {
+                Ok(profile) => profile,
+                Err(error) => {
+                    eprintln!("❌ ERROR: {error}");
+                    std::process::exit(1);
+                }
+            };
+
+            if let Err(error) = profile_to_run_request(&profile, &file_type_groups, &presets) {
+                eprintln!("❌ ERROR: {error}");
+                std::process::exit(1);
+            }
+
+            let profile_name = profile.name.clone();
+            if let Err(error) = save_profile(profile, args.force) {
+                eprintln!("❌ ERROR: {error}");
+                std::process::exit(1);
+            }
+            println!("✅ Saved profile '{profile_name}'.");
+            std::process::exit(0);
+        }
+        Some(Command::RunProfile { name }) => run_profile_command(&name),
         Some(Command::Run(args)) => {
             let file_type_groups = get_filetypes();
             let presets = get_presets();
@@ -68,24 +107,48 @@ fn main() {
                 }
             };
 
-            let open_after = built.request.open_after;
-            let extensions_used = built.extensions_used.clone();
-            let summary = match generate_tag_output(built.request) {
-                Ok(summary) => summary,
-                Err(e) => {
-                    eprintln!("❌ ERROR: Could not generate tag output: {}", e);
-                    std::process::exit(1);
-                }
-            };
-
-            if open_after {
-                open_output_file(&summary);
-            }
-
-            print_cli_summary(&summary, &extensions_used);
-            std::process::exit(0);
+            run_built_request(built);
         }
     }
+}
+
+fn run_profile_command(name: &str) -> ! {
+    let profiles = load_profiles();
+    let Some(profile) = find_profile(&profiles, name) else {
+        eprintln!("❌ ERROR: Profile '{name}' does not exist.");
+        std::process::exit(1);
+    };
+
+    let file_type_groups = get_filetypes();
+    let presets = get_presets();
+    let built = match profile_to_run_request(profile, &file_type_groups, &presets) {
+        Ok(built) => built,
+        Err(error) => {
+            eprintln!("❌ ERROR: {error}");
+            std::process::exit(1);
+        }
+    };
+
+    run_built_request(built);
+}
+
+fn run_built_request(built: crate::cli::BuiltRunRequest) -> ! {
+    let open_after = built.request.open_after;
+    let extensions_used = built.extensions_used.clone();
+    let summary = match generate_tag_output(built.request) {
+        Ok(summary) => summary,
+        Err(e) => {
+            eprintln!("❌ ERROR: Could not generate tag output: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    if open_after {
+        open_output_file(&summary);
+    }
+
+    print_cli_summary(&summary, &extensions_used);
+    std::process::exit(0);
 }
 
 fn run_gui_flow() {
@@ -160,6 +223,25 @@ fn run_gui_flow() {
     }
 
     std::process::exit(0);
+}
+
+fn list_profiles() {
+    let profiles = load_profiles();
+    if profiles.is_empty() {
+        println!("No profiles saved.");
+        return;
+    }
+
+    for profile in profiles {
+        let file_type = profile.file_type.as_deref().unwrap_or("custom extensions");
+        println!(
+            "{}: dir={} file-type={} output={}",
+            profile.name,
+            profile.dir.display(),
+            file_type,
+            profile.output.display()
+        );
+    }
 }
 
 fn list_file_types() {

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -1,0 +1,265 @@
+use crate::cli::{build_run_request, BuiltRunRequest, RunArgs};
+use crate::filetypes::FileTypeGroup;
+use crate::presets::PresetCommand;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{Error, ErrorKind};
+use std::path::{Path, PathBuf};
+
+pub const PROFILES_FILE: &str = "profiles.json";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunProfile {
+    pub name: String,
+    pub dir: PathBuf,
+    pub file_type: Option<String>,
+    pub extensions: Vec<String>,
+    pub recursive: bool,
+    pub ignored_folders: Vec<String>,
+    pub output: PathBuf,
+    pub copy: bool,
+    pub open: bool,
+    pub presets: Vec<String>,
+    pub additional_commands: Option<String>,
+}
+
+pub fn load_profiles() -> Vec<RunProfile> {
+    load_profiles_from_path(PROFILES_FILE).unwrap_or_default()
+}
+
+pub fn save_profiles(profiles: &[RunProfile]) -> std::io::Result<()> {
+    save_profiles_to_path(PROFILES_FILE, profiles)
+}
+
+pub fn find_profile<'a>(profiles: &'a [RunProfile], name: &str) -> Option<&'a RunProfile> {
+    profiles.iter().find(|profile| profile.name == name)
+}
+
+pub fn load_profiles_from_path(path: impl AsRef<Path>) -> std::io::Result<Vec<RunProfile>> {
+    let path = path.as_ref();
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let data = fs::read_to_string(path)?;
+    if data.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    serde_json::from_str(&data).map_err(|error| Error::new(ErrorKind::InvalidData, error))
+}
+
+pub fn save_profiles_to_path(
+    path: impl AsRef<Path>,
+    profiles: &[RunProfile],
+) -> std::io::Result<()> {
+    let data = serde_json::to_string_pretty(profiles)
+        .map_err(|error| Error::new(ErrorKind::InvalidData, error))?;
+    fs::write(path, data)
+}
+
+pub fn profile_from_run_args(name: String, args: RunArgs) -> Result<RunProfile, String> {
+    if name.trim().is_empty() {
+        return Err("Profile name is required.".to_string());
+    }
+
+    let additional_commands = crate::cli::resolve_additional_commands(
+        args.additional_commands_file.as_ref(),
+        args.additional_commands.as_deref(),
+    )?;
+
+    Ok(RunProfile {
+        name,
+        dir: args.dir,
+        file_type: args.file_type,
+        extensions: args.extensions,
+        recursive: args.recursive,
+        ignored_folders: args.ignored_folders,
+        output: args.output,
+        copy: args.copy,
+        open: args.open,
+        presets: args.presets,
+        additional_commands: if additional_commands.trim().is_empty() {
+            None
+        } else {
+            Some(additional_commands)
+        },
+    })
+}
+
+pub fn save_profile(profile: RunProfile, force: bool) -> Result<(), String> {
+    let mut profiles = load_profiles();
+    upsert_profile(&mut profiles, profile, force)?;
+    save_profiles(&profiles).map_err(|error| format!("Failed to save profiles: {error}"))
+}
+
+pub fn upsert_profile(
+    profiles: &mut Vec<RunProfile>,
+    profile: RunProfile,
+    force: bool,
+) -> Result<(), String> {
+    if profile.name.trim().is_empty() {
+        return Err("Profile name is required.".to_string());
+    }
+
+    if let Some(existing_index) = profiles.iter().position(|p| p.name == profile.name) {
+        if !force {
+            return Err(format!(
+                "Profile '{}' already exists. Re-run with --force to overwrite it.",
+                profile.name
+            ));
+        }
+        profiles[existing_index] = profile;
+    } else {
+        profiles.push(profile);
+    }
+
+    Ok(())
+}
+
+pub fn delete_profile(name: &str) -> Result<(), String> {
+    let mut profiles = load_profiles();
+    delete_profile_from_list(&mut profiles, name)?;
+    save_profiles(&profiles).map_err(|error| format!("Failed to save profiles: {error}"))
+}
+
+pub fn delete_profile_from_list(profiles: &mut Vec<RunProfile>, name: &str) -> Result<(), String> {
+    if name.trim().is_empty() {
+        return Err("Profile name is required.".to_string());
+    }
+
+    let initial_len = profiles.len();
+    profiles.retain(|profile| profile.name != name);
+
+    if profiles.len() == initial_len {
+        return Err(format!("Profile '{name}' does not exist."));
+    }
+
+    Ok(())
+}
+
+pub fn profile_to_run_request(
+    profile: &RunProfile,
+    file_type_groups: &[FileTypeGroup],
+    presets: &[PresetCommand],
+) -> Result<BuiltRunRequest, String> {
+    if !profile.dir.is_dir() {
+        return Err(format!(
+            "Profile '{}' directory '{}' does not exist or is not a folder.",
+            profile.name,
+            profile.dir.display()
+        ));
+    }
+
+    build_run_request(profile.clone().into_run_args(), file_type_groups, presets)
+        .map_err(|error| format!("Profile '{}': {error}", profile.name))
+}
+
+impl RunProfile {
+    fn into_run_args(self) -> RunArgs {
+        RunArgs {
+            dir: self.dir,
+            file_type: self.file_type,
+            extensions: self.extensions,
+            recursive: self.recursive,
+            ignored_folders: self.ignored_folders,
+            output: self.output,
+            copy: self.copy,
+            open: self.open,
+            presets: self.presets,
+            additional_commands: self.additional_commands,
+            additional_commands_file: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn profile(name: &str) -> RunProfile {
+        RunProfile {
+            name: name.to_string(),
+            dir: PathBuf::from("."),
+            file_type: Some("Rust".to_string()),
+            extensions: vec!["toml".to_string()],
+            recursive: true,
+            ignored_folders: vec!["target".to_string()],
+            output: PathBuf::from("context.txt"),
+            copy: false,
+            open: true,
+            presets: vec!["Known".to_string()],
+            additional_commands: Some("extra".to_string()),
+        }
+    }
+
+    #[test]
+    fn save_and_reload_profiles_from_temp_json_file() -> std::io::Result<()> {
+        let temp = tempdir()?;
+        let path = temp.path().join("profiles.json");
+        let profiles = vec![profile("daily")];
+
+        save_profiles_to_path(&path, &profiles)?;
+        let reloaded = load_profiles_from_path(&path)?;
+
+        assert_eq!(reloaded, profiles);
+        Ok(())
+    }
+
+    #[test]
+    fn find_profile_by_exact_name() {
+        let profiles = vec![profile("daily"), profile("Daily")];
+
+        let found = find_profile(&profiles, "daily").expect("profile should exist");
+
+        assert_eq!(found.name, "daily");
+        assert!(find_profile(&profiles, "DAILY").is_none());
+    }
+
+    #[test]
+    fn reject_duplicate_save_without_force() {
+        let mut profiles = vec![profile("daily")];
+        let error = upsert_profile(&mut profiles, profile("daily"), false)
+            .expect_err("duplicate should fail without force");
+
+        assert!(error.contains("already exists"));
+        assert!(error.contains("--force"));
+    }
+
+    #[test]
+    fn delete_existing_profile() {
+        let mut profiles = vec![profile("daily"), profile("weekly")];
+
+        delete_profile_from_list(&mut profiles, "daily").expect("delete should succeed");
+
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].name, "weekly");
+    }
+
+    #[test]
+    fn deleting_missing_profile_returns_useful_error() {
+        let mut profiles = vec![profile("daily")];
+
+        let error = delete_profile_from_list(&mut profiles, "missing")
+            .expect_err("missing profile should fail");
+
+        assert!(error.contains("Profile 'missing' does not exist"));
+    }
+
+    #[test]
+    fn running_profile_with_unknown_file_type_errors_before_generation() -> std::io::Result<()> {
+        let temp = tempdir()?;
+        let mut profile = profile("bad-type");
+        profile.dir = temp.path().to_path_buf();
+        profile.file_type = Some("Unknown".to_string());
+        profile.extensions.clear();
+
+        let error =
+            profile_to_run_request(&profile, &[], &[]).expect_err("unknown file type should fail");
+
+        assert!(error.contains("Profile 'bad-type'"));
+        assert!(error.contains("Unknown file type group 'Unknown'"));
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a second-phase profile system for storing reusable generation requests in a single file `profiles.json` so users can save and re-run complex CLI invocations without repeating arguments.
- Reuse the existing shared generation layer rather than duplicating logic, and surface clear CLI errors for invalid profiles or inputs.

### Description
- Add a new module `src/profiles.rs` introducing `RunProfile`, persistence helpers (`load_profiles`, `save_profiles`, `load_profiles_from_path`, `save_profiles_to_path`), and profile management helpers (`find_profile`, `upsert_profile`, `delete_profile`, `delete_profile_from_list`).
- Wire CLI subcommands for profile management: `save-profile` (with `--force`), `run-profile`, `list-profiles`, and `delete-profile`, and add `SaveProfileArgs` to flatten the existing `RunArgs` for saving.
- Convert profiles into the shared `TagGenerationRequest` flow via `profile_to_run_request` which calls the existing `build_run_request`, and call the shared generator `generate_tag_output` from `run_built_request` so generation logic is not duplicated.
- Add input validation and helpful errors for missing profile names, duplicate saves (requires `--force` to overwrite), missing/non-directory folders, unknown file type groups, and unknown presets, and expose `PROFILES_FILE` as `profiles.json`; also make `resolve_additional_commands` `pub(crate)` so it can be reused.

### Testing
- Ran `cargo test` which completed successfully (`34 passed; 0 failed`).
- Built the project with `cargo build` which finished successfully.
- Performed a manual CLI smoke test in a temporary directory that executed `save-profile`, `list-profiles`, `run-profile`, and `delete-profile` in sequence and produced the expected outputs (profile saved, generation succeeded, profile deleted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20cd73b4848332b10a21fe48609686)