### PR TITLE
docs: add CLI usage examples and script templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,108 @@ cargo build --release
 - Choose or manage filetype groups (Rust, JSON, Web, etc.)  
 - Enable recursion and ignore folders if needed  
 - Add manual instructions or select a preset  
-- Output is written to `tags_output.txt`  
+- Output is written to `tags_output.txt` by default, or to the custom path you enter  
 - Optionally copies output to your clipboard  
+
+### CLI Examples
+
+The CLI uses the same shared generation engine as the GUI, so tagged output, recursive traversal, ignored folders, additional commands, presets, and clipboard copy behavior are generated consistently whether you run interactively or from a script.
+
+Run without a subcommand to launch the GUI:
+
+```sh
+code-file-wrapper
+```
+
+Launch the GUI explicitly:
+
+```sh
+code-file-wrapper gui
+```
+
+List configured file type groups from `filetypes.json`:
+
+```sh
+code-file-wrapper list-file-types
+```
+
+Generate Rust context from the current directory recursively. Without `--output`, the CLI writes to the default `tags_output.txt`:
+
+```sh
+code-file-wrapper run --dir . --file-type Rust --recursive
+```
+
+Use a custom output filename for repeatable no-GUI workflows:
+
+```sh
+code-file-wrapper run --dir . --file-type Rust --recursive --output rust_context.txt
+```
+
+Select individual extensions instead of a file type group. Repeat `--ext` once per extension:
+
+```sh
+code-file-wrapper run --dir . --ext rs --ext toml --ext md --recursive
+```
+
+Copy the generated output to the clipboard after writing the output file:
+
+```sh
+code-file-wrapper run --dir . --file-type Rust --recursive --copy
+```
+
+Profiles are optional convenience helpers for saving command arguments, but they are not required for repeatability. A checked-in shell, PowerShell, or batch script that calls `code-file-wrapper run` with explicit arguments is fully repeatable without using profiles.
+
+#### PowerShell Script Template
+
+```powershell
+$CodeFileWrapper = "C:\Tools\code-file-wrapper\code-file-wrapper.exe"
+$ProjectPath = "C:\Projects\my-rust-app"
+$OutputPath = Join-Path $ProjectPath "rust_context.txt"
+$CopyToClipboard = $false  # Set to $true to also copy output after writing the file.
+
+$Arguments = @(
+    "run",
+    "--dir", $ProjectPath,
+    "--file-type", "Rust",
+    "--recursive",
+    "--ignore", "target",
+    "--ignore", ".git",
+    "--output", $OutputPath
+)
+
+if ($CopyToClipboard) {
+    $Arguments += "--copy"
+}
+
+& $CodeFileWrapper @Arguments
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+```
+
+#### Windows Batch Script Template
+
+```bat
+@echo off
+set "CODE_FILE_WRAPPER=C:\Tools\code-file-wrapper\code-file-wrapper.exe"
+set "PROJECT_PATH=C:\Projects\my-rust-app"
+set "OUTPUT_PATH=%PROJECT_PATH%\rust_context.txt"
+set "COPY_TO_CLIPBOARD=0"
+
+set "COPY_ARG="
+if "%COPY_TO_CLIPBOARD%"=="1" set "COPY_ARG=--copy"
+
+"%CODE_FILE_WRAPPER%" run ^
+  --dir "%PROJECT_PATH%" ^
+  --file-type Rust ^
+  --recursive ^
+  --ignore target ^
+  --ignore .git ^
+  --output "%OUTPUT_PATH%" ^
+  %COPY_ARG%
+
+if errorlevel 1 exit /b %errorlevel%
+```
 
 ### Windows CLI and GUI Tradeoff
 
@@ -99,7 +199,7 @@ graph TD;
     E --> G[Scan Files]
     F --> G
     G --> H[Wrap Files with <RelativePath> Tags]
-    H --> I[Write to tags_output.txt]
+    H --> I[Write to selected output file]
     I --> J[Append Presets + Additional Commands]
     J --> K{Copy to Clipboard?}
     K -->|Yes| L[Copy Output]


### PR DESCRIPTION
### Motivation

- Provide a no-GUI, repeatable workflow in the README so users can run the generator from scripts or shells.
- Show accurate CLI examples that match the actual Clap argument names used by the program.
- Offer platform-friendly script templates (PowerShell and Windows batch) demonstrating ignored folders, custom outputs, and optional clipboard copy.

### Description

- Added a new "CLI Examples" section documenting `code-file-wrapper`, `code-file-wrapper gui`, `code-file-wrapper list-file-types`, and `code-file-wrapper run` usage with flags such as `--dir`, `--file-type`, `--ext`, `--recursive`, `--ignore`, `--output`, and `--copy`.
- Included example commands requested in the spec, including `--ext` repetition and `--output` for custom filenames, and clarified that the CLI uses the same shared generation engine as the GUI.
- Added a PowerShell script template and a Windows batch script template that use variables for the executable and project path, include `--ignore target` and `--ignore .git`, set a custom `--output`, and optionally add `--copy`.
- Updated README wording and the mermaid flow diagram to avoid implying the output is always `tags_output.txt` and to reflect that a custom output path may be used.

### Testing

- Ran `cargo test` and all unit tests passed (34 passed, 0 failed). 
- Ran `cargo run -- --help` and `cargo run -- run --help` to confirm the README examples use the actual Clap argument names and defaults, and both help commands executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20cfec39508332af875a9fabb5d4de)