### PR TITLE
Add focused generation and CLI tests

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -313,12 +313,14 @@ mod tests {
     }
 
     #[test]
-    fn build_run_request_combines_and_deduplicates_extensions() {
+    fn build_run_request_combines_and_deduplicates_extensions() -> std::io::Result<()> {
+        let temp = tempdir()?;
+        let dir = temp.path().to_str().expect("temp path is UTF-8");
         let args = Cli::try_parse_from([
             "code-file-wrapper",
             "run",
             "--dir",
-            ".",
+            dir,
             "--file-type",
             "Rust",
             "--ext",
@@ -335,11 +337,15 @@ mod tests {
 
         assert_eq!(built.extensions_used, vec!["rs", "toml"]);
         assert_eq!(built.request.extensions, vec!["rs", "toml"]);
+        assert_eq!(built.request.root_dir, temp.path());
+        Ok(())
     }
 
     #[test]
-    fn build_run_request_requires_extensions() {
-        let args = Cli::try_parse_from(["code-file-wrapper", "run", "--dir", "."])
+    fn build_run_request_requires_file_type_or_ext_before_generation() -> std::io::Result<()> {
+        let temp = tempdir()?;
+        let dir = temp.path().to_str().expect("temp path is UTF-8");
+        let args = Cli::try_parse_from(["code-file-wrapper", "run", "--dir", dir])
             .expect("CLI should parse");
         let Some(Command::Run(args)) = args.command else {
             panic!("expected run command");
@@ -348,6 +354,33 @@ mod tests {
         let error = build_run_request(args, &rust_group(), &[]).expect_err("expected error");
 
         assert!(error.contains("Provide --file-type"));
+        assert!(error.contains("--ext"));
+        Ok(())
+    }
+
+    #[test]
+    fn unknown_file_type_lists_available_groups() -> std::io::Result<()> {
+        let temp = tempdir()?;
+        let dir = temp.path().to_str().expect("temp path is UTF-8");
+        let args = Cli::try_parse_from([
+            "code-file-wrapper",
+            "run",
+            "--dir",
+            dir,
+            "--file-type",
+            "Go",
+        ])
+        .expect("CLI should parse");
+        let Some(Command::Run(args)) = args.command else {
+            panic!("expected run command");
+        };
+
+        let error = build_run_request(args, &rust_group(), &[]).expect_err("expected error");
+
+        assert!(error.contains("Unknown file type group 'Go'"));
+        assert!(error.contains("Available file type groups"));
+        assert!(error.contains("- Rust"));
+        Ok(())
     }
 
     #[test]
@@ -355,11 +388,12 @@ mod tests {
         let temp = tempdir()?;
         let additional_path = temp.path().join("additional.txt");
         fs::write(&additional_path, "from file")?;
+        let dir = temp.path().to_str().expect("temp path is UTF-8");
         let args = Cli::try_parse_from([
             "code-file-wrapper",
             "run",
             "--dir",
-            ".",
+            dir,
             "--ext",
             "rs",
             "--additional-file",
@@ -380,11 +414,13 @@ mod tests {
 
     #[test]
     fn unknown_preset_lists_available_presets() {
+        let temp = tempdir().expect("tempdir should be created");
+        let dir = temp.path().to_str().expect("temp path is UTF-8");
         let args = Cli::try_parse_from([
             "code-file-wrapper",
             "run",
             "--dir",
-            ".",
+            dir,
             "--ext",
             "rs",
             "--preset",

--- a/src/file_ops.rs
+++ b/src/file_ops.rs
@@ -391,106 +391,111 @@ mod tests {
         vec!["target".to_string(), ".git".to_string()]
     }
 
+    fn project_fixture() -> std::io::Result<(tempfile::TempDir, std::path::PathBuf)> {
+        let temp = tempdir()?;
+        let project = temp.path().join("project");
+        fs::create_dir_all(&project)?;
+        Ok((temp, project))
+    }
+
     fn tag_for(relative_path: impl AsRef<Path>) -> String {
         relative_path.as_ref().to_string_lossy().into_owned()
     }
 
     #[test]
-    fn custom_output_path_creates_requested_file() -> std::io::Result<()> {
-        let temp = tempdir()?;
-        let root = temp.path();
-        fs::write(root.join("main.rs"), "fn main() {}")?;
-        let output_path = root.join("custom_output.txt");
+    fn custom_output_path_creates_requested_file_without_tags_output_txt() -> std::io::Result<()> {
+        let (temp, project) = project_fixture()?;
+        fs::create_dir_all(project.join("src"))?;
+        fs::write(project.join("src").join("main.rs"), "fn main() {}")?;
+        let output_path = temp.path().join("project_context.txt");
 
-        let summary =
-            write_folder_tags(root, &valid_exts(), false, &ignored_folders(), &output_path)?;
+        let summary = write_folder_tags(&project, &valid_exts(), true, &[], &output_path)?;
 
         assert!(output_path.exists());
+        assert!(!temp.path().join("tags_output.txt").exists());
+        assert!(!project.join("tags_output.txt").exists());
         assert_eq!(summary.files_written, 1);
         let output = fs::read_to_string(output_path)?;
-        assert!(output.contains("<main.rs>"));
+        let main_tag = tag_for(Path::new("src").join("main.rs"));
+        assert!(output.contains(&format!("<{main_tag}>")));
         assert!(output.contains("fn main() {}"));
 
         Ok(())
     }
 
     #[test]
-    fn tags_output_txt_is_not_created_for_different_output_path() -> std::io::Result<()> {
-        let temp = tempdir()?;
-        let root = temp.path();
-        fs::write(root.join("main.rs"), "fn main() {}")?;
-        let output_path = root.join("requested_output.txt");
+    fn recursive_search_includes_all_nested_matching_files() -> std::io::Result<()> {
+        let (temp, project) = project_fixture()?;
+        fs::create_dir_all(project.join("src"))?;
+        fs::write(project.join("src").join("main.rs"), "fn main() {}")?;
+        fs::write(project.join("src").join("lib.rs"), "pub fn lib() {}")?;
+        let output_path = temp.path().join("recursive_output.txt");
 
-        write_folder_tags(root, &valid_exts(), false, &ignored_folders(), &output_path)?;
+        let summary = write_folder_tags(&project, &valid_exts(), true, &[], &output_path)?;
 
-        assert!(output_path.exists());
-        assert!(!root.join("tags_output.txt").exists());
-
-        Ok(())
-    }
-
-    #[test]
-    fn recursive_search_includes_nested_matching_files() -> std::io::Result<()> {
-        let temp = tempdir()?;
-        let root = temp.path();
-        fs::create_dir(root.join("nested"))?;
-        fs::write(root.join("nested").join("lib.rs"), "pub fn nested() {}")?;
-        let output_path = root.join("recursive_output.txt");
-
-        let summary =
-            write_folder_tags(root, &valid_exts(), true, &ignored_folders(), &output_path)?;
-
-        assert_eq!(summary.files_written, 1);
+        assert_eq!(summary.files_written, 2);
         let output = fs::read_to_string(output_path)?;
-        let nested_tag = tag_for(Path::new("nested").join("lib.rs"));
-        assert!(output.contains(&format!("<{nested_tag}>")));
-        assert!(output.contains("pub fn nested() {}"));
+        let main_tag = tag_for(Path::new("src").join("main.rs"));
+        let lib_tag = tag_for(Path::new("src").join("lib.rs"));
+        assert!(output.contains(&format!("<{main_tag}>")));
+        assert!(output.contains(&format!("<{lib_tag}>")));
+        assert!(output.contains("fn main() {}"));
+        assert!(output.contains("pub fn lib() {}"));
 
         Ok(())
     }
 
     #[test]
-    fn non_recursive_search_excludes_nested_matching_files() -> std::io::Result<()> {
-        let temp = tempdir()?;
-        let root = temp.path();
-        fs::write(root.join("main.rs"), "fn main() {}")?;
-        fs::create_dir(root.join("nested"))?;
-        fs::write(root.join("nested").join("lib.rs"), "pub fn nested() {}")?;
-        let output_path = root.join("non_recursive_output.txt");
+    fn non_recursive_search_includes_only_top_level_matching_files() -> std::io::Result<()> {
+        let (temp, project) = project_fixture()?;
+        fs::write(project.join("main.rs"), "fn main() {}")?;
+        fs::create_dir_all(project.join("src"))?;
+        fs::write(project.join("src").join("lib.rs"), "pub fn lib() {}")?;
+        let output_path = temp.path().join("non_recursive_output.txt");
 
-        let summary =
-            write_folder_tags(root, &valid_exts(), false, &ignored_folders(), &output_path)?;
+        let summary = write_folder_tags(&project, &valid_exts(), false, &[], &output_path)?;
 
         assert_eq!(summary.files_written, 1);
         let output = fs::read_to_string(output_path)?;
         assert!(output.contains("<main.rs>"));
-        assert!(!output.contains("pub fn nested() {}"));
+        assert!(output.contains("fn main() {}"));
+        assert!(!output.contains("pub fn lib() {}"));
+        assert!(!output.contains(&tag_for(Path::new("src").join("lib.rs"))));
 
         Ok(())
     }
 
     #[test]
     fn ignored_folders_are_skipped_during_recursive_search() -> std::io::Result<()> {
-        let temp = tempdir()?;
-        let root = temp.path();
-        fs::write(root.join("main.rs"), "fn main() {}")?;
-        fs::create_dir(root.join("target"))?;
+        let (temp, project) = project_fixture()?;
+        fs::create_dir_all(project.join("src"))?;
+        fs::write(project.join("src").join("main.rs"), "fn main() {}")?;
+        fs::create_dir_all(project.join("target"))?;
         fs::write(
-            root.join("target").join("generated.rs"),
-            "pub fn target() {}",
+            project.join("target").join("generated.rs"),
+            "pub fn generated() {}",
         )?;
-        fs::create_dir(root.join(".git"))?;
-        fs::write(root.join(".git").join("ignored.rs"), "pub fn git() {}")?;
-        let output_path = root.join("ignored_output.txt");
+        fs::create_dir_all(project.join(".git"))?;
+        fs::write(project.join(".git").join("config"), "[core]")?;
+        let output_path = temp.path().join("ignored_output.txt");
 
-        let summary =
-            write_folder_tags(root, &valid_exts(), true, &ignored_folders(), &output_path)?;
+        let summary = write_folder_tags(
+            &project,
+            &valid_exts(),
+            true,
+            &ignored_folders(),
+            &output_path,
+        )?;
 
         assert_eq!(summary.files_written, 1);
         let output = fs::read_to_string(output_path)?;
+        let main_tag = tag_for(Path::new("src").join("main.rs"));
+        assert!(output.contains(&format!("<{main_tag}>")));
         assert!(output.contains("fn main() {}"));
-        assert!(!output.contains("pub fn target() {}"));
-        assert!(!output.contains("pub fn git() {}"));
+        assert!(!output.contains("pub fn generated() {}"));
+        assert!(!output.contains("target"));
+        assert!(!output.contains(".git"));
+        assert!(!output.contains("[core]"));
 
         Ok(())
     }

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -125,20 +125,57 @@ mod tests {
     }
 
     #[test]
-    fn generate_tag_output_uses_custom_output_path() -> std::io::Result<()> {
+    fn generate_tag_output_uses_custom_output_path_without_tags_output_txt() -> std::io::Result<()>
+    {
         let temp = tempdir()?;
-        let root = temp.path().to_path_buf();
-        fs::write(root.join("main.rs"), "fn main() {}")?;
-        let output_path = root.join("custom-tags.txt");
+        let project = temp.path().join("project");
+        fs::create_dir_all(project.join("src"))?;
+        fs::write(project.join("src").join("main.rs"), "fn main() {}")?;
+        let output_path = temp.path().join("project_context.txt");
+        let mut request = request(project.clone(), output_path.clone());
+        request.recursive = true;
 
-        let summary = generate_tag_output(request(root.clone(), output_path.clone()))?;
+        let summary = generate_tag_output(request)?;
 
         assert_eq!(summary.output_path, output_path);
         assert_eq!(summary.files_written, 1);
-        assert!(summary.files_skipped == 0);
+        assert_eq!(summary.files_skipped, 0);
         assert!(output_path.exists());
-        assert!(!root.join("tags_output.txt").exists());
-        assert!(fs::read_to_string(output_path)?.contains("<main.rs>"));
+        assert!(!temp.path().join("tags_output.txt").exists());
+        assert!(!project.join("tags_output.txt").exists());
+        let output = fs::read_to_string(output_path)?;
+        assert!(output.contains("main.rs"));
+        assert!(output.contains("fn main() {}"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn generate_tag_output_honors_recursive_and_ignore_options() -> std::io::Result<()> {
+        let temp = tempdir()?;
+        let project = temp.path().join("project");
+        fs::create_dir_all(project.join("src"))?;
+        fs::write(project.join("src").join("main.rs"), "fn main() {}")?;
+        fs::write(project.join("src").join("lib.rs"), "pub fn lib() {}")?;
+        fs::create_dir_all(project.join("target"))?;
+        fs::write(
+            project.join("target").join("generated.rs"),
+            "pub fn generated() {}",
+        )?;
+        let output_path = temp.path().join("context.txt");
+        let mut request = request(project, output_path.clone());
+        request.recursive = true;
+        request.ignored_folders = vec!["target".to_string()];
+
+        let summary = generate_tag_output(request)?;
+
+        assert_eq!(summary.files_written, 2);
+        assert!(summary.recursive);
+        let output = fs::read_to_string(output_path)?;
+        assert!(output.contains("main.rs"));
+        assert!(output.contains("lib.rs"));
+        assert!(!output.contains("generated.rs"));
+        assert!(!output.contains("pub fn generated() {}"));
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- Prevent regressions in the new shared generation path and ensure CLI and GUI share the same generation logic.
- Protect against hard-coded `tags_output.txt` behavior and verify custom output paths are honored.
- Ensure file-type group resolution, recursion, ignored-folder handling, and CLI parsing behave correctly across platforms.

### Description
- Add tempfile-backed unit tests to `src/file_ops.rs` that create a `project` fixture and assert custom output creation, recursive vs non-recursive file discovery, and ignored-folder skipping while verifying `tags_output.txt` is not created.
- Add generation-level tests to `src/generation.rs` exercising `TagGenerationRequest` for custom output path, recursive discovery, and ignored folders to validate the shared non-GUI generation flow.
- Strengthen CLI tests in `src/cli.rs` to use `Cli::try_parse_from` with `tempdir()`-backed directories and assert `build_run_request` behavior for correct extension resolution, missing-extension validation, unknown file-type error messaging (lists available groups), and additional-command merging.
- Ensure `tempfile` is available for tests by having `tempfile = "3"` under `[dev-dependencies]` in `Cargo.toml`.

### Testing
- Ran `cargo fmt -- --check && cargo test` as an automated verification step.
- All unit tests passed: `35 passed; 0 failed`; tests exercise filesystem scenarios via `tempfile::tempdir` and do not rely on the repository working directory (CWD).
- Test run surfaced unrelated `gui` deprecation warnings but did not affect test results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20d1dcb8648332885c52309bf52ab0)