### PR TITLE
Refresh documentation: clarify shared generation path and output behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,16 @@ cargo build --release
 ## 🚀 Usage
 
 ### Launch GUI  
+Running the binary without arguments launches the GUI.
+
 ```sh
 ./target/release/code-file-wrapper
+```
+
+You can also launch the GUI explicitly from an installed binary:
+
+```sh
+code-file-wrapper gui
 ```
 
 ### GUI Actions  
@@ -76,12 +84,12 @@ cargo build --release
 - Choose or manage filetype groups (Rust, JSON, Web, etc.)  
 - Enable recursion and ignore folders if needed  
 - Add manual instructions or select a preset  
-- Output is written to `tags_output.txt` by default, or to the custom path you enter  
+- The output field defaults to `tags_output.txt`; edit it to write to any non-directory output path
 - Optionally copies output to your clipboard  
 
 ### CLI Examples
 
-The CLI uses the same shared generation engine as the GUI, so tagged output, recursive traversal, ignored folders, additional commands, presets, and clipboard copy behavior are generated consistently whether you run interactively or from a script.
+The CLI uses the same shared generation engine as the GUI, so tagged output, recursive traversal, ignored folders, additional commands, presets, output-path handling, and clipboard copy behavior are generated consistently whether you run interactively or from a script.
 
 Run without a subcommand to launch the GUI:
 
@@ -101,13 +109,13 @@ List configured file type groups from `filetypes.json`:
 code-file-wrapper list-file-types
 ```
 
-Generate Rust context from the current directory recursively. Without `--output`, the CLI writes to the default `tags_output.txt`:
+Generate Rust context from the current directory recursively. Without `--output`, the CLI writes to `tags_output.txt` in the current working directory:
 
 ```sh
 code-file-wrapper run --dir . --file-type Rust --recursive
 ```
 
-Use a custom output filename for repeatable no-GUI workflows:
+Use `--output <path>` to override the CLI default output path for repeatable no-GUI workflows:
 
 ```sh
 code-file-wrapper run --dir . --file-type Rust --recursive --output rust_context.txt
@@ -124,6 +132,22 @@ Copy the generated output to the clipboard after writing the output file:
 ```sh
 code-file-wrapper run --dir . --file-type Rust --recursive --copy
 ```
+
+### Default Output Behavior
+
+- No arguments launches the GUI: `code-file-wrapper`.
+- The GUI output field starts as `tags_output.txt`, and you can replace it with a custom file path before clicking **OK**.
+- The CLI `run` subcommand defaults `--output` to `tags_output.txt`.
+- Both GUI and CLI reject an output path that already points to a directory; use a filename instead.
+
+### CLI Error Behavior
+
+The CLI validates arguments before or during generation and exits non-zero on errors. Common cases are:
+
+- **Unknown file type group:** `--file-type <name>` must match a group from `filetypes.json`; run `code-file-wrapper list-file-types` to see valid names.
+- **Missing extension selection:** `code-file-wrapper run --dir .` is invalid because `run` needs either `--file-type <group>` or at least one `--ext <extension>`.
+- **Invalid directory:** `--dir <path>` must exist and be a directory.
+- **Output path is a directory:** `--output <path>` must name a file path, not an existing folder.
 
 Profiles are optional convenience helpers for saving command arguments, but they are not required for repeatability. A checked-in shell, PowerShell, or batch script that calls `code-file-wrapper run` with explicit arguments is fully repeatable without using profiles.
 
@@ -189,23 +213,30 @@ The tradeoff is that launching the GUI build directly on Windows may show a cons
 
 ## 📜 How It Works
 
+### Architecture
+
+The application has one shared generation path for both interactive and scripted use:
+
+- The GUI gathers selections, then `main.rs` builds a `TagGenerationRequest`.
+- The CLI parses `code-file-wrapper run ...`, then `cli.rs` builds a `TagGenerationRequest`.
+- Both flows call `generate_tag_output` in `src/generation.rs`.
+- `src/file_ops.rs` only scans directories and writes/appends files; it does not parse CLI arguments, run GUI dialogs, or own output-path defaults.
+
 ```mermaid
 graph TD;
-    A[Start] --> B[Open GUI]
-    B --> C[Select Directory & File Type Group]
-    C --> D[Enable Recursive Search?]
-    D -->|Yes| E[Setup Ignore Folder List]
-    D -->|No| F[Proceed]
-    E --> G[Scan Files]
-    F --> G
-    G --> H[Wrap Files with <RelativePath> Tags]
-    H --> I[Write to selected output file]
-    I --> J[Append Presets + Additional Commands]
-    J --> K{Copy to Clipboard?}
-    K -->|Yes| L[Copy Output]
-    K -->|No| M[Prompt to Open File]
-    L --> N[Done]
-    M --> N
+    A[Start] --> B{Entry point}
+    B -->|No args or gui| C[GUI selections]
+    B -->|run| D[CLI arguments]
+    C --> E[Build TagGenerationRequest]
+    D --> E
+    E --> F[generate_tag_output]
+    F --> G[file_ops scans selected files]
+    G --> H[file_ops writes selected output file]
+    H --> I[Append Presets + Additional Commands]
+    I --> J{Copy to Clipboard?}
+    J -->|Yes| K[Copy Output]
+    J -->|No| L[Return Summary]
+    K --> L
 ```
 
 ---

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,24 @@
+//! # CLI Module
+//!
+//! Defines command-line arguments and converts non-interactive runs into [`TagGenerationRequest`] values.
+//! Running the binary with no subcommand is handled by `main.rs` and launches the GUI; the `run`
+//! subcommand uses this module to validate arguments before calling the shared generation path.
+//!
+//! # Defaults and Overrides
+//! - `run` defaults `--output` to `tags_output.txt`.
+//! - Supplying `--output <path>` overrides the default output file.
+//! - Callers must provide either `--file-type <group>` or one or more `--ext <extension>` values.
+//!
+//! # Error Behavior
+//! - Unknown file type groups return a message with the available groups.
+//! - Missing extension selection returns a message asking for `--file-type` or `--ext`.
+//! - Invalid directories are rejected before generation.
+//! - Output paths that already point to directories are rejected by `generate_tag_output`.
+//!
+//! # Architecture Notes
+//! The CLI does not write tagged output directly. It builds a request, then `main.rs` passes that
+//! request to `generate_tag_output`, matching the GUI architecture and avoiding duplicate generation paths.
+
 use crate::filetypes::{find_filetype_group, format_available_filetype_groups, FileTypeGroup};
 use crate::generation::TagGenerationRequest;
 use crate::presets::PresetCommand;

--- a/src/file_ops.rs
+++ b/src/file_ops.rs
@@ -1,19 +1,20 @@
 //! # File Operations Module
 //!
-//! This module is responsible for processing files in a directory by reading their contents,
-//! filtering by file extension, and writing them into a caller-selected tagged output file.
+//! Provides low-level filesystem helpers for scanning directories and writing tagged output files.
+//! Higher-level GUI/CLI orchestration lives in `generation`, `gui`, `cli`, and `main`; this module
+//! intentionally does not decide defaults, parse arguments, show dialogs, or choose generation paths.
 //!
 //! # Features
 //! - Recursively or non-recursively scan directories.
 //! - Filter files by allowed extensions.
 //! - Skip hidden or user-specified folders.
 //! - Wrap file contents in XML-style tags based on relative path.
-//! - Append instructional or command-based sections at the end of the output.
+//! - Append instructional or command-based sections to whichever output file the caller supplies.
 //!
 //! # Key Functions
-//! - [`write_folder_tags`]: Top-level entry point for generating tagged file output.
+//! - [`write_folder_tags`]: Creates/overwrites a caller-selected tagged output file.
 //! - [`write_folder_tags_recursive`]: Internal recursive helper for deep directory traversal.
-//! - [`append_additional_commands`]: Appends extra user-defined command blocks.
+//! - [`append_additional_commands`]: Appends extra user-defined command blocks to a caller-selected file.
 //! - [`is_human_readable`]: Checks if a file has an allowed extension.
 //!
 //! # Output Behavior
@@ -96,7 +97,7 @@ pub struct WriteFolderTagsSummary {
 /// let dir = Path::new("src");
 /// let exts = vec!["rs".to_string(), "toml".to_string()];
 /// let ignored = vec!["target".to_string(), ".git".to_string()];
-/// let output_path = Path::new("tags_output.txt");
+/// let output_path = Path::new("project_context.txt");
 /// write_folder_tags(dir, &exts, true, &ignored, output_path)?;
 /// ```
 pub fn write_folder_tags(
@@ -232,7 +233,7 @@ fn write_tagged_file(
 /// instructions, prompts, or commands that should be interpreted after the code sections.
 ///
 /// # Parameters
-/// - `file_path`: Path to the file to append to (typically `"tags_output.txt"`).
+/// - `file_path`: Path to the caller-selected output file to append to.
 /// - `additional_commands`: Multiline string of user-defined commands or instructions to include.
 ///
 /// # Behavior
@@ -265,7 +266,7 @@ fn write_tagged_file(
 ///
 /// # Example
 /// ```rust
-/// append_additional_commands("tags_output.txt", "TODO: Review all unwrap() usages.")?;
+/// append_additional_commands("project_context.txt", "TODO: Review all unwrap() usages.")?;
 /// ```
 ///
 /// # See Also
@@ -330,7 +331,7 @@ pub fn append_additional_commands(
 /// # Example
 /// ```rust
 /// let root = Path::new("src");
-/// let mut output = File::create("tags_output.txt")?;
+/// let mut output = File::create("project_context.txt")?;
 /// let ignored = vec!["target".to_string(), ".git".to_string()];
 /// let valid_exts = vec!["rs".to_string()];
 /// let mut summary = WriteFolderTagsSummary::default();

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -1,8 +1,16 @@
 //! Shared output generation orchestration.
 //!
-//! This module contains the non-GUI generation flow used to build tagged output files,
-//! append preset/manual command text, and optionally copy the final output to the clipboard.
-//! Callers remain responsible for presenting dialogs or opening generated files.
+//! This module is the single generation path used by both GUI and CLI entry points. Each
+//! caller translates user input into a [`TagGenerationRequest`] and then calls
+//! [`generate_tag_output`] to scan files, write tagged output, append preset/manual text,
+//! and optionally copy the result to the clipboard.
+//!
+//! # Architecture Notes
+//! - GUI and CLI flows should build requests instead of generating output independently.
+//! - [`generate_tag_output`] validates generation-level inputs such as the root directory and output path.
+//! - `file_ops.rs` remains limited to scanning and writing files; it does not own defaults or UI/CLI behavior.
+//! - Output paths are caller-selected: both current entry points default to `tags_output.txt`, but both can override it.
+//! - Callers remain responsible for presenting dialogs, printing summaries, or opening generated files.
 
 use crate::file_ops::{append_additional_commands, write_folder_tags};
 use crate::utils::copy_to_clipboard;

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,9 +1,12 @@
 //! # GUI Module
 //!
-//! Provides the graphical interface for selecting directories, file types, and preset commands.
+//! Provides the graphical interface for selecting directories, file types, output paths, and preset commands.
+//! The GUI gathers selections only; `main.rs` converts them into a `TagGenerationRequest` and calls
+//! `generate_tag_output` so the GUI does not maintain a separate generation implementation.
 //!
 //! # Purpose
 //! - Allows users to configure how the application processes files.
+//! - Starts with `tags_output.txt` as the default output path while allowing the user to enter a custom path.
 //! - Enables selection of presets, additional instructions, and clipboard behavior.
 //! - Offers management tools to create, edit, and delete command presets.
 //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,20 @@
 //! # Main Entry Point
 //!
-//! Coordinates program execution, launching the GUI and processing user-selected files.
+//! Coordinates application startup and routes execution to either the GUI flow or a CLI
+//! subcommand. Running with no subcommand launches the GUI; `run` and profile subcommands
+//! build a CLI-driven request instead.
 //!
 //! # Responsibilities
-//! - Starts the GUI and gathers user input.
-//! - Validates directory and mode selections.
-//! - Initiates file reading, filtering, and output generation.
-//! - Optionally copies the final result to the clipboard or opens it in Notepad.
+//! - Parses top-level CLI commands and dispatches GUI, generation, profile, and listing flows.
+//! - Supplies the GUI with its default output path (`tags_output.txt`) while allowing users to edit it.
+//! - Converts GUI selections into a [`TagGenerationRequest`].
+//! - Passes every GUI and CLI generation request to [`generate_tag_output`] so output creation stays centralized.
+//! - Handles presentation-only behavior such as CLI summaries, GUI dialogs, and optional file opening.
 //!
-//! # Key Functions
-//! - [`main`]: The primary entry point. Launches the app, orchestrates all major steps.
-//! - [`mode_selection_gui`]: Wrapper that runs the GUI and returns user selections.
-//!
-//! # Dependencies
-//! - Relies on `generation` for tag generation orchestration.
-//! - Relies on `gui` for user input.
-//! - Relies on `utils` for clipboard and cursor behavior.
-//! - Relies on `presets` for saved preset data.
-//!
-//! # Output
-//! - Generates or updates the selected output file.
+//! # Architecture Notes
+//! - GUI and CLI code should not duplicate tagged-output generation logic.
+//! - `main.rs` orchestrates entry points, then delegates filesystem scanning/writing through `generation`.
+//! - The selected output path may be the default `tags_output.txt` or any caller-provided file path.
 
 mod cli;
 mod file_ops;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,7 +12,7 @@
 //!
 //! # Use Cases
 //! - GUI positioning based on current cursor location.
-//! - Copying output (`tags_output.txt`) to the clipboard for easy pasting into external tools (e.g., chatbots, editors).
+//! - Copying the selected output file to the clipboard for easy pasting into external tools (e.g., chatbots, editors).
 //!
 //! # Notes
 //! - Functions in this module are designed to fail gracefully and never panic.
@@ -59,8 +59,8 @@ use std::io;
 ///
 /// # Example
 /// ```rust
-/// copy_to_clipboard("tags_output.txt")?;
-/// println!("Copied tags_output.txt to clipboard.");
+/// copy_to_clipboard("project_context.txt")?;
+/// println!("Copied project_context.txt to clipboard.");
 /// ```
 #[cfg(windows)]
 pub fn copy_to_clipboard(file_path: &str) -> io::Result<()> {


### PR DESCRIPTION
### Motivation
- Make documentation accurate about where tagged-output is produced and remove statements implying the output file is always hard-coded. 
- Surface the architecture that GUI and CLI both build a `TagGenerationRequest` and both call a single generation path so generation logic is not duplicated.

### Description
- Update `README.md` to clarify that running with no arguments launches the GUI, that the GUI and the CLI default `--output` to `tags_output.txt` but both can override the output path, add a short architecture section, and document common CLI error cases (unknown file type group, missing extension selection, invalid directory, output path that is a directory). 
- Refresh module-level documentation in `src/main.rs`, `src/file_ops.rs`, `src/gui.rs`, `src/generation.rs`, `src/cli.rs`, and `src/utils.rs` to emphasize the single shared generation flow, caller-selected output paths, and that `file_ops.rs` only scans/writes files. 
- Adjust README examples and inline examples in module docs so they match the actual accepted CLI/GUI arguments and avoid implying a hard-coded output file. 
- Minor doc-example updates in `file_ops.rs` and `utils.rs` so examples reference caller-selected filenames instead of implying `tags_output.txt` is hard-coded.

### Testing
- Ran `cargo test` and all unit tests passed (`35` passed, `0` failed). 
- Ran `cargo build` and exercised the binary with `target/debug/code-file-wrapper list-file-types` and `target/debug/code-file-wrapper run --dir . --file-type Rust --recursive --output <tmpfile>` which completed successfully. 
- Verified formatting and checks with `cargo fmt --check` and `git diff --check` with no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a229e7e18e88332b099229d4b93cf10)